### PR TITLE
Stub development/test only rake tasks in production

### DIFF
--- a/lib/tasks/bundle_audit.rake
+++ b/lib/tasks/bundle_audit.rake
@@ -1,2 +1,11 @@
-require "bundler/audit/task"
-Bundler::Audit::Task.new
+begin
+  require "bundler/audit/task"
+  Bundler::Audit::Task.new
+rescue LoadError
+  namespace :bundle do
+    desc "Audit gems for CVEs"
+    task :audit do
+      warn "bundler-audit is not available. Skipping bundle:audit task."
+    end
+  end
+end

--- a/lib/tasks/reek.rake
+++ b/lib/tasks/reek.rake
@@ -1,5 +1,14 @@
-require "reek/rake/task"
+begin
+  require "reek/rake/task"
 
-Reek::Rake::Task.new do |t|
-  t.fail_on_error = false
+  Reek::Rake::Task.new do |t|
+    t.fail_on_error = false
+  end
+rescue LoadError
+  namespace :reek do
+    desc "Run Reek"
+    task :run do
+      warn "reek is not available. Skipping reek:run task."
+    end
+  end
 end

--- a/lib/tasks/standard.rake
+++ b/lib/tasks/standard.rake
@@ -1,0 +1,7 @@
+begin
+  require "standard/rake"
+rescue LoadError
+  task :standard do
+    warn "standard is not available. Skipping standard rake task."
+  end
+end


### PR DESCRIPTION
When deploying Rails app, rake cannot load tasks for gems available only in development/test:

```
rake aborted!
LoadError: cannot load such file -- bundler/audit/task (LoadError)
```

Adds rescue blocks and defines fallback tasks for non development/test environments.