### PR TITLE
Add Github deploy action to run on main after verify

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows:
+      - Verify
+    branches:
+      - main
+    types:
+      - completed
+
+concurrency:
+  group: production
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Deploy to Hatchbox
+        uses: hatchboxio/github-hatchbox-deploy-action@v2
+        with:
+          deploy_key: ${{ secrets.HATCHBOX_DEPLOY_KEY }}


### PR DESCRIPTION
Additional steps:

- Disabled automatic deploys on Hatchbox
- Added Github action secret for Hatchbox deploy key in repo settings

Resources:

- https://mattbrictson.com/blog/deploy-rails-with-github-actions https://docs.github.com/en/actions
- https://stackoverflow.com/questions/64951853/run-deployment-workflow-if-tests-workflow-is-passed 
- https://github.com/hatchboxio/github-hatchbox-deploy-action