### PR TITLE
Ensure sqlite3 production warning not emitted

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,4 +96,10 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  if Rails.version <= "7.1.2"
+    config.active_record.sqlite3_production_warning = false
+  else
+    warn "Remove this warning?"
+  end
 end


### PR DESCRIPTION
Despite Litestack having a railtie to disable the Rails 7 sqlite production warning, the warning is still produced in production:

```
$ RAILS_ENV=production bin/rails console
W, [2024-01-12T20:35:31.814660 #89287]  WARN -- : You are running SQLite in production, this is generally not recommended. You can disable this warning by setting "config.active_record.sqlite3_production_warning=false".
Litestack initialized!
Loading production environment (Rails 7.1.2)
Loading config from ~/.irbrc
```

This comes down to load order; the ActiveRecord railtie initializer to emit the warning is run before Litestack's initializer. I could attempt to submit a patch to Litestack but for now I simply disable the warning in the production config here.