### PR TITLE
Limit pwa resource requests to proper formats

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,8 +30,8 @@ Rails.application.routes.draw do
   end
 
   # Render dynamic PWA files from app/views/pwa/*
-  get "serviceworker" => "pwa#serviceworker", :as => :pwa_serviceworker
-  get "manifest" => "pwa#manifest", :as => :pwa_manifest
+  get "serviceworker" => "pwa#serviceworker", :as => :pwa_serviceworker, :constraints => {format: "js"}
+  get "manifest" => "pwa#manifest", :as => :pwa_manifest, :constraints => {format: "json"}
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Homes", type: :request do
+RSpec.describe "Home page", type: :request do
   describe "GET /" do
     it "renders" do
       get "/"

--- a/spec/requests/pwa_spec.rb
+++ b/spec/requests/pwa_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "PWA resources", type: :request do
+  describe "GET /manifest.json" do
+    it "returns the PWA manifest" do
+      get "/manifest.json"
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to match("application/json")
+    end
+
+    it "ignores other formats" do
+      get "/manifest.js"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "GET /serviceworker.js" do
+    it "returns the PWA service worker" do
+      get "/serviceworker.js"
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to match("text/javascript")
+    end
+
+    it "ignores other formats" do
+      get "/serviceworker.json"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
Fixes error

```
ActionView::MissingTemplate: Missing template pwa/manifest with {:locale=>[:en], :formats=>[:js, :html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :md, :markdown, :markerb, :jbuilder]}.
```