### PR TITLE
Configure flipper to skip preload

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,0 +1,3 @@
+Rails.application.configure do
+  config.flipper.memoize = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,21 +12,8 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   sitepress_root
 
-  namespace :admin_users do
-    resources :sessions, only: [:new, :create] do
-      collection do
-        delete "sign_out" => "sessions#destroy", :as => "destroy"
-      end
-    end
-  end
-
   namespace :pwa do
     resource :installation_instructions, only: [:show]
-  end
-
-  scope :admin, constraints: Routes::AdminAccessConstraint.new do
-    mount Liteboard.app => "/liteboard"
-    mount Flipper::UI.app(Flipper) => "/flipper"
   end
 
   # Render dynamic PWA files from app/views/pwa/*
@@ -36,4 +23,17 @@ Rails.application.routes.draw do
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", :as => :rails_health_check
+
+  namespace :admin_users do
+    resources :sessions, only: [:new, :create] do
+      collection do
+        delete "sign_out" => "sessions#destroy", :as => "destroy"
+      end
+    end
+  end
+
+  scope :admin, constraints: Routes::AdminAccessConstraint.new do
+    mount Liteboard.app => "/liteboard"
+    mount Flipper::UI.app(Flipper) => "/flipper"
+  end
 end


### PR DESCRIPTION
Flipper inserts middleware that preloads all Flipper flags into memory.
By default this is run on every request. Since we're using flags
sparingly at the moment, we temporarily disable this behavior
completely. The middleware supports options to control what requests the
flags are preloaded on—this may be helpful should we choose to revisit
at a later date.

![Screenshot 2024-01-16 at 10 09 27 AM](https://github.com/joyofrails/joyofrails.com/assets/11673/9198ae66-b7e6-47e3-a035-d3c75610759f)
