### PR TITLE
Add solid_cache and solid_queue migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "rails", "~> 7.1" # Bundle edge Rails instead: gem "rails", github: "rails/r
 gem "puma", ">= 5.0" # Use the Puma web server [https://github.com/puma/puma]
 gem "sqlite3" # Use sqlite3 as the database for Active Record [https://github.com/sparklemotion/sqlite3-ruby]
 gem "litestack", git: "https://github.com/oldmoe/litestack" # All-in-one solution for SQLite data storage, caching, and background jobs [https://github.com/oldmoe/litestack]
+gem "solid_cache" # A database-backed ActiveSupport::Cache::Store [https://github.com/rails/solid_cache]
 
 gem "rack", "~> 2.2", ">= 2.2.7" # litestack's liteboard depends on hanami-router which does not currently support rack 3.x as of Dec 2023
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "puma", ">= 5.0" # Use the Puma web server [https://github.com/puma/puma]
 gem "sqlite3" # Use sqlite3 as the database for Active Record [https://github.com/sparklemotion/sqlite3-ruby]
 gem "litestack", git: "https://github.com/oldmoe/litestack" # All-in-one solution for SQLite data storage, caching, and background jobs [https://github.com/oldmoe/litestack]
 gem "solid_cache" # A database-backed ActiveSupport::Cache::Store [https://github.com/rails/solid_cache]
+gem "solid_queue" # A database-backed ActiveJob backend [https://github.com/basecamp/solid_queue]
 
 gem "rack", "~> 2.2", ">= 2.2.7" # litestack's liteboard depends on hanami-router which does not currently support rack 3.x as of Dec 2023
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "rails", "~> 7.1" # Bundle edge Rails instead: gem "rails", github: "rails/r
 
 gem "puma", ">= 5.0" # Use the Puma web server [https://github.com/puma/puma]
 gem "sqlite3" # Use sqlite3 as the database for Active Record [https://github.com/sparklemotion/sqlite3-ruby]
-gem "litestack" # All-in-one solution for SQLite data storage, caching, and background jobs [https://github.com/oldmoe/litestack]
+gem "litestack", git: "https://github.com/oldmoe/litestack" # All-in-one solution for SQLite data storage, caching, and background jobs [https://github.com/oldmoe/litestack]
 
 gem "rack", "~> 2.2", ">= 2.2.7" # litestack's liteboard depends on hanami-router which does not currently support rack 3.x as of Dec 2023
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/oldmoe/litestack
+  revision: 70da8ea09d44f218c797cb721e308701516b48b0
+  specs:
+    litestack (0.4.2)
+      erubi
+      hanami-router
+      oj
+      rack
+      sqlite3
+      tilt
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -210,13 +222,6 @@ GEM
     letter_opener (1.8.1)
       launchy (>= 2.2, < 3)
     lint_roller (1.1.0)
-    litestack (0.4.2)
-      erubi
-      hanami-router
-      oj
-      rack
-      sqlite3
-      tilt
     litestream (0.3.1)
     litestream (0.3.1-arm64-darwin)
     litestream (0.3.1-arm64-linux)
@@ -492,7 +497,7 @@ DEPENDENCIES
   inline_svg
   jbuilder
   letter_opener
-  litestack
+  litestack!
   litestream
   mail_interceptor
   markdown-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -411,6 +411,8 @@ GEM
       activejob (>= 7)
       activerecord (>= 7)
       railties (>= 7)
+    solid_queue (0.2.1)
+      rails (~> 7.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -517,6 +519,7 @@ DEPENDENCIES
   selenium-webdriver
   sitepress-rails
   solid_cache
+  solid_queue
   sprockets-rails
   sqlite3
   standard

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,7 +393,8 @@ GEM
     sanitize (6.1.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    selenium-webdriver (4.16.0)
+    selenium-webdriver (4.17.0)
+      base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -406,6 +407,10 @@ GEM
       sitepress-core (= 4.0.2)
       sprockets-rails (>= 2.0.0)
     smart_properties (1.17.0)
+    solid_cache (0.4.2)
+      activejob (>= 7)
+      activerecord (>= 7)
+      railties (>= 7)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -511,6 +516,7 @@ DEPENDENCIES
   rspec-rails
   selenium-webdriver
   sitepress-rails
+  solid_cache
   sprockets-rails
   sqlite3
   standard

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,37 +4,29 @@
 #   Ensure the SQLite 3 gem is defined in your Gemfile
 #   gem "sqlite3"
 #
-# `Litesupport.root.join("data.sqlite3")` stores
-# application data in the path `./db/#{Rails.env}/data.sqlite3`
-#
-# `Litesupport.root(env).join(path)` stores 
-# application data in the path `./db/#{env}/#{path}`
-#
-# idle_timeout should be set to zero, to avoid recycling sqlite connections
-# and losing the page cache
-# 
 default: &default
-  adapter: litedb
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  idle_timeout: 0
+  adapter: sqlite3
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 3 } %>
+  timeout: 5000
 
 development:
   <<: *default
-  database: <%= Litesupport.root("development").join("data.sqlite3") %>
+  database: storage/development/data.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: <%= Litesupport.root("test").join("data.sqlite3") %>
+  database: storage/test/data.sqlite3
 
-# Warning: Make sure your production database path is on a persistent
-# volume, otherwise your application data could be deleted between deploys.
+
+# SQLite3 write its data on the local filesystem, as such it requires
+# persistent disks. If you are deploying to a managed service, you should
+# make sure it provides disk persistence, as many don't.
 #
-# You may also set the Litesupport.root in production via the
-# `LITESTACK_DATA_PATH` environment variable.
+# Similarly, if you deploy your application as a Docker container, you must
+# ensure the database is located in a persisted volume.
 production:
   <<: *default
-  database: <%= Litesupport.root("production").join("data.sqlite3") %>
-
+  database: storage/production/data.sqlite3

--- a/db/cache_schema.rb
+++ b/db/cache_schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2024_02_10_145644) do
+  create_table "solid_cache_entries", force: :cascade do |t|
+    t.binary "key", limit: 1024, null: false
+    t.binary "value", limit: 536870912, null: false
+    t.datetime "created_at", null: false
+    t.integer "key_hash", limit: 8, null: false
+    t.integer "byte_size", limit: 4, null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
+  end
+end

--- a/db/migrate_cache/20240210145644_create_solid_cache_entries.solid_cache.rb
+++ b/db/migrate_cache/20240210145644_create_solid_cache_entries.solid_cache.rb
@@ -1,0 +1,16 @@
+# This migration comes from solid_cache (originally 20230724121448)
+class CreateSolidCacheEntries < ActiveRecord::Migration[7.0]
+  def change
+    create_table :solid_cache_entries do |t|
+      t.binary :key, null: false, limit: 1024
+      t.binary :value, null: false, limit: 512.megabytes
+      t.datetime :created_at, null: false
+      t.integer :key_hash, null: false, limit: 8
+      t.integer :byte_size, null: false, limit: 4
+
+      t.index :key_hash, unique: true
+      t.index [:key_hash, :byte_size]
+      t.index :byte_size
+    end
+  end
+end

--- a/db/migrate_queue/20240211043212_create_solid_queue_tables.solid_queue.rb
+++ b/db/migrate_queue/20240211043212_create_solid_queue_tables.solid_queue.rb
@@ -1,0 +1,101 @@
+# This migration comes from solid_queue (originally 20231211200639)
+class CreateSolidQueueTables < ActiveRecord::Migration[7.0]
+  def change
+    create_table :solid_queue_jobs do |t|
+      t.string :queue_name, null: false
+      t.string :class_name, null: false, index: true
+      t.text :arguments
+      t.integer :priority, default: 0, null: false
+      t.string :active_job_id, index: true
+      t.datetime :scheduled_at
+      t.datetime :finished_at, index: true
+      t.string :concurrency_key
+
+      t.timestamps
+
+      t.index [:queue_name, :finished_at], name: "index_solid_queue_jobs_for_filtering"
+      t.index [:scheduled_at, :finished_at], name: "index_solid_queue_jobs_for_alerting"
+    end
+
+    create_table :solid_queue_scheduled_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.datetime :scheduled_at, null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [:scheduled_at, :priority, :job_id], name: "index_solid_queue_dispatch_all"
+    end
+
+    create_table :solid_queue_ready_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [:priority, :job_id], name: "index_solid_queue_poll_all"
+      t.index [:queue_name, :priority, :job_id], name: "index_solid_queue_poll_by_queue"
+    end
+
+    create_table :solid_queue_claimed_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.bigint :process_id
+      t.datetime :created_at, null: false
+
+      t.index [:process_id, :job_id]
+    end
+
+    create_table :solid_queue_blocked_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.string :concurrency_key, null: false
+      t.datetime :expires_at, null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [:expires_at, :concurrency_key], name: "index_solid_queue_blocked_executions_for_maintenance"
+    end
+
+    create_table :solid_queue_failed_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.text :error
+      t.datetime :created_at, null: false
+    end
+
+    create_table :solid_queue_pauses do |t|
+      t.string :queue_name, null: false, index: {unique: true}
+      t.datetime :created_at, null: false
+    end
+
+    create_table :solid_queue_processes do |t|
+      t.string :kind, null: false
+      t.datetime :last_heartbeat_at, null: false, index: true
+      t.bigint :supervisor_id, index: true
+
+      t.integer :pid, null: false
+      t.string :hostname
+      t.text :metadata
+
+      t.datetime :created_at, null: false
+    end
+
+    create_table :solid_queue_semaphores do |t|
+      t.string :key, null: false, index: {unique: true}
+      t.integer :value, default: 1, null: false
+      t.datetime :expires_at, null: false, index: true
+
+      t.timestamps
+
+      t.index [:key, :value], name: "index_solid_queue_semaphores_on_key_and_value"
+    end
+
+    add_foreign_key :solid_queue_blocked_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_claimed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_failed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_ready_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_scheduled_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+  end
+end

--- a/db/migrate_queue/20240211043213_add_missing_index_to_blocked_executions.solid_queue.rb
+++ b/db/migrate_queue/20240211043213_add_missing_index_to_blocked_executions.solid_queue.rb
@@ -1,0 +1,6 @@
+# This migration comes from solid_queue (originally 20240110143450)
+class AddMissingIndexToBlockedExecutions < ActiveRecord::Migration[7.1]
+  def change
+    add_index :solid_queue_blocked_executions, [:concurrency_key, :priority, :job_id], name: "index_solid_queue_blocked_executions_for_release"
+  end
+end

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -1,0 +1,21 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 0) do
+  create_table "queue", id: :text, default: -> { "hex(randomblob(32))" }, force: :cascade do |t|
+    t.text "name", default: "default", null: false
+    t.integer "fire_at", default: -> { "unixepoch()" }, null: false
+    t.text "value"
+    t.integer "created_at", default: -> { "unixepoch()" }, null: false
+    t.index ["name", "fire_at"], name: "idx_queue_by_name"
+  end
+end


### PR DESCRIPTION
This deploy adds solid_cache and solid_queue to the bundle. We also upgrade litestack to edge which includes fixes for dbconsole.

Both solid_cache and solid_queue provide migrations which are included as well. We deploy migrations separately ahead of code and configuration changes for a graceful restart.
