### PR TITLE
Configure solid_cache and solid_queue

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: env RUBY_DEBUG_OPEN=true bin/rails server
 vite: bin/vite dev
+jobs: bin/rails solid_queue:start

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,5 +41,10 @@ module Joy
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    if SolidCache::VERSION > "0.4.2" && Rails.env.local?
+      raise "Check to see if we can remove this config setting below"
+    end
+    config.solid_cache.connects_to = {database: {writing: :cache, reading: :cache}}
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,6 @@ module Joy
       raise "Check to see if we can remove this config setting below"
     end
     config.solid_cache.connects_to = {database: {writing: :cache, reading: :cache}}
+    config.solid_queue.connects_to = {database: {writing: :queue, reading: :queue}}
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :litecache
+    config.cache_store = :solid_cache_store
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,5 +75,5 @@ Rails.application.configure do
   config.action_controller.raise_on_missing_callback_actions = true
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  config.active_job.queue_adapter = :litejob
+  config.active_job.queue_adapter = :solid_queue
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,9 +69,8 @@ Rails.application.configure do
   config.cache_store = :solid_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter = :resque
   # config.active_job.queue_name_prefix = "joy_production"
-  config.active_job.queue_adapter = :litejob
+  config.active_job.queue_adapter = :solid_queue
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,7 +66,7 @@ Rails.application.configure do
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Use a different cache store in production.
-  config.cache_store = :litecache
+  config.cache_store = :solid_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter = :resque

--- a/config/solid_cache.yml
+++ b/config/solid_cache.yml
@@ -1,0 +1,24 @@
+default: &default
+  store_options: &default_store_options
+    max_age: <%= 60.days.to_i %>
+    namespace: <%= Rails.env %>
+  size_estimate_samples: 1000
+
+development:
+  database: cache
+  store_options:
+    <<: *default_store_options
+    max_size: <%= 256.megabytes %>
+
+test:
+  database: cache
+  store_options:
+    <<: *default_store_options
+    max_age: <%= 1.hour.to_i %>
+    max_size: <%= 512.megabytes %>
+
+production:
+  database: cache
+  store_options:
+    <<: *default_store_options
+    max_entries: <%= 4.gigabytes %>

--- a/config/solid_queue.yml
+++ b/config/solid_queue.yml
@@ -1,0 +1,18 @@
+# default: &default
+#   dispatchers:
+#     - polling_interval: 1
+#       batch_size: 500
+#   workers:
+#     - queues: "*"
+#       threads: 5
+#       processes: 1
+#       polling_interval: 0.1
+#
+# development:
+#  <<: *default
+#
+# test:
+#  <<: *default
+#
+# production:
+#  <<: *default


### PR DESCRIPTION
The new default active job adapter is solid_queue. The new default Rails cache adapter is solid_cache. Both backends will rely on sqlite. We do this mostly for simplicity and to stay consistent with what we believe to be future defaults in Rails. This may not be the most performant setup, but it is much simpler than managing an extra server in Redis or Memcached.

We set up configuration for solid_cache and solid_queue to use our new multi-database config in `config/database.yml` which is an idea we've taken from `litestack` for sqlite app database design.

We've added a `config/solid_cache.yml` based on the `solid_cache` README, but it is not yet being picked up with the most recent release—we'll need to doublecheck this config when solid_cache is updated in the future.

