### PR TITLE
Add activerecord-enhancedsqlite3-adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,9 @@ gem "rails", "~> 7.1" # Bundle edge Rails instead: gem "rails", github: "rails/r
 
 gem "puma", ">= 5.0" # Use the Puma web server [https://github.com/puma/puma]
 gem "sqlite3" # Use sqlite3 as the database for Active Record [https://github.com/sparklemotion/sqlite3-ruby]
+gem "activerecord-enhancedsqlite3-adapter" # Enhanced SQLite3 adapter for Active Record [https://github.com/fractaledmind/activerecord-enhancedsqlite3-adapter]
 gem "litestack", git: "https://github.com/oldmoe/litestack" # All-in-one solution for SQLite data storage, caching, and background jobs [https://github.com/oldmoe/litestack]
+
 gem "solid_cache" # A database-backed ActiveSupport::Cache::Store [https://github.com/rails/solid_cache]
 gem "solid_queue" # A database-backed ActiveJob backend [https://github.com/basecamp/solid_queue]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,9 @@ GEM
       activemodel (= 7.1.3.2)
       activesupport (= 7.1.3.2)
       timeout (>= 0.4.0)
+    activerecord-enhancedsqlite3-adapter (0.5.0)
+      activerecord (>= 7.1)
+      sqlite3 (~> 1.6)
     activestorage (7.1.3.2)
       actionpack (= 7.1.3.2)
       activejob (= 7.1.3.2)
@@ -485,6 +488,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-enhancedsqlite3-adapter
   bcrypt (~> 3.1.7)
   bootsnap
   brakeman


### PR DESCRIPTION
Adding initially to address

```
ActiveRecord::StatementInvalid (SQLite3::BusyException: database is locked)
```

This often happens during a deploy, I suspect, when we have a graceful deploy across old and new Rails processes.

More context on the solution from the gem author here: 

- https://fractaledmind.github.io/2023/12/11/sqlite-on-rails-improving-concurrency/
- https://fractaledmind.github.io/2023/12/06/sqlite-on-rails-improving-the-enhanced-sqlite3-adapter/