### PR TITLE
Remove litestack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-LITESTACK_DATA_PATH=./storage

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,20 +4,6 @@ name: Verify
 on: [push]
 
 jobs:
-  deploy-notice-test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Setup Ruby and install gems
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-
-      - name: Notify Honeybadger
-        run: RAILS_ENV=test bundle exec honeybadger deploy --environment test --revision ${{ github.sha }} --repository ${{ github.repository }} --user ${{ github.actor }} --api-key ${{ secrets.HONEYBADGER_API_KEY }}
-
   linters:
     name: Linters
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem "rails", "~> 7.1" # Bundle edge Rails instead: gem "rails", github: "rails/r
 gem "puma", ">= 5.0" # Use the Puma web server [https://github.com/puma/puma]
 gem "sqlite3" # Use sqlite3 as the database for Active Record [https://github.com/sparklemotion/sqlite3-ruby]
 gem "activerecord-enhancedsqlite3-adapter" # Enhanced SQLite3 adapter for Active Record [https://github.com/fractaledmind/activerecord-enhancedsqlite3-adapter]
-gem "litestack", git: "https://github.com/oldmoe/litestack" # All-in-one solution for SQLite data storage, caching, and background jobs [https://github.com/oldmoe/litestack]
 
 gem "solid_cache" # A database-backed ActiveSupport::Cache::Store [https://github.com/rails/solid_cache]
 gem "solid_queue" # A database-backed ActiveJob backend [https://github.com/basecamp/solid_queue]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,3 @@
-GIT
-  remote: https://github.com/oldmoe/litestack
-  revision: 70da8ea09d44f218c797cb721e308701516b48b0
-  specs:
-    litestack (0.4.2)
-      erubi
-      hanami-router
-      oj
-      rack
-      sqlite3
-      tilt
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -197,11 +185,6 @@ GEM
       sanitize (< 7)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    hanami-router (2.0.2)
-      mustermann (~> 3.0)
-      mustermann-contrib (~> 3.0)
-      rack (~> 2.0)
-    hansi (0.2.1)
     hashdiff (1.0.1)
     honeybadger (5.4.1)
     i18n (1.14.1)
@@ -251,11 +234,6 @@ GEM
     mini_mime (1.1.5)
     minitest (5.22.2)
     msgpack (1.7.2)
-    mustermann (3.0.0)
-      ruby2_keywords (~> 0.0.1)
-    mustermann-contrib (3.0.0)
-      hansi (~> 0.2.0)
-      mustermann (= 3.0.0)
     mutex_m (0.2.0)
     net-imap (0.4.10)
       date
@@ -275,8 +253,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
-    oj (3.16.3)
-      bigdecimal (>= 3.0)
     openssl (3.2.0)
     parallel (1.23.0)
     parser (3.3.0.5)
@@ -390,7 +366,6 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sanitize (6.1.0)
       crass (~> 1.0.2)
@@ -442,7 +417,6 @@ GEM
       railties (>= 6.0.0)
     stringio (3.1.0)
     thor (1.3.1)
-    tilt (2.3.0)
     timeout (0.4.1)
     turbo-rails (1.5.0)
       actionpack (>= 6.0.0)
@@ -507,7 +481,6 @@ DEPENDENCIES
   inline_svg
   jbuilder
   letter_opener
-  litestack!
   litestream
   mail_interceptor
   markdown-rails

--- a/app/lib/litestream_extensions/setup.rb
+++ b/app/lib/litestream_extensions/setup.rb
@@ -1,6 +1,6 @@
 module LitestreamExtensions
   module Setup
-    LITESTACK_DATABASES_FOR_LITESTREAM = %w[data metrics queue]
+    DATABASES_FOR_LITESTREAM = %w[data metrics queue]
 
     module_function
 
@@ -14,7 +14,7 @@ module LitestreamExtensions
 
     def litestream_config
       {
-        "dbs" => LITESTACK_DATABASES_FOR_LITESTREAM.map do |db|
+        "dbs" => DATABASES_FOR_LITESTREAM.map do |db|
           {
             "path" => File.join(litestack_data_path, Rails.env, "#{db}.sqlite3"),
             "replicas" => [{"url" => "s3://#{litestream_bucket}/#{Rails.env}/#{db}.sqlite3"}]

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,8 +1,8 @@
 development:
-  adapter: litecable
+  adapter: async
 
 test:
   adapter: test
 
 production:
-  adapter: litecable
+  adapter: async

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,3 @@
-require "litestack/liteboard/liteboard"
-
 require_relative "../app/lib/routes/admin_access_constraint"
 
 # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
@@ -34,7 +32,6 @@ Rails.application.routes.draw do
   end
 
   scope :admin, constraints: Routes::AdminAccessConstraint.new do
-    mount Liteboard.app => "/liteboard"
     mount Flipper::UI.app(Flipper) => "/flipper"
   end
 end

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -5,12 +5,6 @@ RSpec.describe "Admin", type: :request do
     context "when signed in as admin user" do
       before { login_admin_user }
 
-      it "renders liteboard" do
-        get "/admin/liteboard"
-
-        expect(response.status).to eq(200)
-      end
-
       it "renders flipper-ui" do
         get "/admin/flipper/features"
 


### PR DESCRIPTION
Having replaced litedb with sqlite adapter, litecache with solid cache, and litequeue with solid queue, it's increasingly hard to justify keeping litestack. I've found it difficult to configure and not as robust as I would like; for example, it's not currently possible to require pieces of litestack so it's all or nothing. 

This changeset removes all litestack dependencies and references.

A key missing piece is a Sqlite-backed Action Cable adapter. There's an open issue in Rails that suggests this may be a part of Rails 8 in the future: https://github.com/rails/rails/issues/50480. For now, we fall back to the default `async` adapter for action cable which will have to do for the time being.