### PR TITLE
Fix vite css bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@
 
 # Vite Ruby
 /public/vite*
+/public/build*
 node_modules
 # Vite uses dotenv and suggests to ignore local-only env files. See
 # https://vitejs.dev/guide/env-and-mode.html#env-files

--- a/app/javascript/entrypoints/application.css
+++ b/app/javascript/entrypoints/application.css
@@ -1,0 +1,1 @@
+@import '../css/application.css';

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -2,7 +2,6 @@ import debug from 'debug';
 
 import '@hotwired/turbo-rails';
 import '../controllers';
-import '../css/application.css';
 
 import { turboScrollSmoothWorkaround } from '../initializers';
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,12 +13,10 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= render "application/config" %>
-    <%= vite_client_tag %>
     <%= render "darkmode/setup" %>
-    <%= unless ViteRuby.instance.dev_server_running?
-      vite_stylesheet_tag "application", media: "all", "data-turbo-track": "reload"
-    end %>
-    <%= vite_javascript_tag "application", media: "all", "data-turbo-track": "reload" %>
+    <%= vite_client_tag %>
+    <%= vite_stylesheet_tag "application.css", media: "all", "data-turbo-track": "reload" %>
+    <%= vite_javascript_tag "application.js", media: "all", "data-turbo-track": "reload" %>
     <script defer data-domain="joyofrails.com" src="https://plausible.io/js/script.js"></script>
   </head>
   <%= tag.body class: body_classes do %>

--- a/config/vite.json
+++ b/config/vite.json
@@ -1,16 +1,17 @@
 {
   "all": {
     "sourceCodeDir": "app/javascript",
-    "watchAdditionalPaths": []
+    "watchAdditionalPaths": [],
+    "publicOutputDir": "build"
   },
   "development": {
     "autoBuild": true,
-    "publicOutputDir": "vite-dev",
+    "publicOutputDir": "build-dev",
     "port": 3036
   },
   "test": {
     "autoBuild": true,
-    "publicOutputDir": "vite-test",
+    "publicOutputDir": "build-test",
     "port": 3037
   }
 }


### PR DESCRIPTION
Vite is generating a link tag for a stylesheet with a javascript bundle:

```
<link rel="stylesheet" href="/vite/assets/application-w40geAFS.js" media="all" data-turbo-track="reload" /> 
```

For now, the fix is to move the css import into application.css.

We also adjust the vite config for build output directory to avoid leaking "vite" in html source.