### PR TITLE
Update settings for Rails logging

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: env RUBY_DEBUG_OPEN=true bin/rails server
+web: env RAILS_LOG_TO_STDOUT=${RAILS_LOG_TO_STDOUT:=true} RUBY_DEBUG_OPEN=true bin/rails server
+jobs: env RAILS_LOG_TO_STDOUT=${RAILS_LOG_TO_STDOUT:=true} RAILS_LOG_LEVEL=warn bin/rails solid_queue:start
 vite: bin/vite dev -- --clearScreen=false
-jobs: bin/rails solid_queue:start

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,5 +47,10 @@ module Joy
     end
     config.solid_cache.connects_to = {database: {writing: :cache, reading: :cache}}
     config.solid_queue.connects_to = {database: {writing: :queue, reading: :queue}}
+
+    # Log to STDOUT
+    if ENV["RAILS_LOG_TO_STDOUT"] == "true"
+      config.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new($stdout))
+    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -76,4 +76,6 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :solid_queue
+
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "debug")
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -61,4 +61,7 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Limit logging in test environment
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "warn")
 end


### PR DESCRIPTION
Provide env vars to customize Rails logging from command line, e.g:

```sh
RAILS_LOG_LEVEL=warn RAILS_LOG_TO_STDOUT=true
```

Log to $stdout by default in development with Procfile

Tune down logging for tests and Solid Queue in development.
