### PR TITLE
Use "packs" for vite public output dir

### DIFF
--- a/config/vite.json
+++ b/config/vite.json
@@ -2,16 +2,16 @@
   "all": {
     "sourceCodeDir": "app/javascript",
     "watchAdditionalPaths": [],
-    "publicOutputDir": "build"
+    "publicOutputDir": "packs"
   },
   "development": {
     "autoBuild": true,
-    "publicOutputDir": "build-dev",
+    "publicOutputDir": "packs",
     "port": 3036
   },
   "test": {
     "autoBuild": true,
-    "publicOutputDir": "build-test",
+    "publicOutputDir": "packs-test",
     "port": 3037
   }
 }


### PR DESCRIPTION
Hatchbox Caddy configuration provides proper Cache-Control headers for requests under /assets/* and /packs/*. Though we may be able to customize the Hatchbox Caddy settings throughtheir UI, following their convention may be the lowest point of friction right now.

Following this change, we expect requests for vite-controlled assets to change the `Cache-Control` response header from `no-cache` to one with `max-age` applied.