### PR TITLE
Make ErbMarkdown aware of code fences

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -6,5 +6,15 @@ exclude:
   - '**/node_modules/**/*'
 
 linters:
-  ErbSafety:
+  AllowedScriptType:
     enabled: true
+    allowed_types:
+      - 'application/json'
+      - 'application/ld+json'
+      - 'module'
+      - 'text/html'
+      - 'text/javascript'
+      - 'text/ruby'
+      - 'text/template'
+    allow_blank: false
+    disallow_inline_scripts: false

--- a/app/markdown/erb_markdown.rb
+++ b/app/markdown/erb_markdown.rb
@@ -6,6 +6,38 @@ class ErbMarkdown < ApplicationMarkdown
   # This works great, except when you have an `erb` code fence.
   def preprocess(html)
     # Read more about this render call at https://guides.rubyonrails.org/layouts_and_rendering.html
-    render(inline: html, handler: :erb).gsub("_ERB_", "")
+    unescape_erb render(inline: escape_erb(html), handler: :erb)
+  end
+
+  def unescape_erb(html)
+    html.gsub("%%", "%")
+  end
+
+  # Converts ERB tags inside code fences to `%%` to avoid processing ERB inside code fences.
+  #
+  # Solution adapted from:
+  # https://stackoverflow.com/questions/65028292/using-regex-to-find-multiple-matches-between-two-strings
+  #
+  # Imagine a string like this:
+  #
+  #   c x c x A c x c x c B c x c x
+  #
+  # Find any "c" character that is between "A" and "B". So in this example I need to get 3 matches.
+  #
+  # Given A and B are different single character strings, use negated character classes:
+  #
+  # (?:\G(?!^)|A)[^AB]*?\Kc(?=[^AB]*B)
+  # See this regex demo. Details:
+  #
+  # * (?:\G(?!^)|A) - A or end of the previous successful match
+  # * [^AB]*? - any zero or more chars other than A and B, as few as possible
+  # * \K - match reset operator that discards all text matched so far in the overall memory match buffer
+  # * c - a c char/string
+  # * (?=[^AB]*B) - that must be followed with zero or more chars other than A and B and then B char immediately to the right of the current location.
+  #
+  def escape_erb(html)
+    html
+      .gsub(/(?:\G(?!^)|`)(.*?)\K<%(?=.*`)/m, "\\2<%%\\3")
+      .gsub(/(?:\G(?!^)|`)(.*?)\K%>(?=.*`)/m, "\\2%%>\\3")
   end
 end

--- a/app/views/components/pwa/_web_push_demo.html.erb
+++ b/app/views/components/pwa/_web_push_demo.html.erb
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
 </script>
 <%= tag.div data: {
     controller: "pwa-web-push-demo",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
     <%= vite_client_tag %>
     <%= vite_stylesheet_tag "application.css", media: "all", "data-turbo-track": "reload" %>
     <%= vite_javascript_tag "application.js", media: "all", "data-turbo-track": "reload" %>
-    <script defer data-domain="joyofrails.com" src="https://plausible.io/js/script.js"></script>
+    <script type="text/javascript" defer data-domain="joyofrails.com" src="https://plausible.io/js/script.js"></script>
   </head>
   <%= tag.body class: body_classes do %>
     <%= yield :top %>

--- a/spec/markdown/erb_markdown_spec.rb
+++ b/spec/markdown/erb_markdown_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe ErbMarkdown do
+  describe "#preprocess" do
+    subject { described_class.new }
+    it "doesn't alter markdown" do
+      expect(subject.preprocess("## Hello")).to eq("## Hello")
+    end
+
+    it "processes unfenced erb" do
+      expect(subject.preprocess("<%= 1 + 1 %>")).to eq("2")
+    end
+
+    it "does not process inline fenced erb" do
+      expect(subject.preprocess("`<%= 1 + 1 %>`")).to eq("`<%= 1 + 1 %>`")
+    end
+
+    it "handles multiline fenced erb" do
+      expect(subject.preprocess("```\n<%= 1 + 1 %>\n```")).to eq("```\n<%= 1 + 1 %>\n```")
+    end
+
+    it "handles multiline fenced with multiple erbs" do
+      html = <<~HTML
+        ```
+        <%= 1 + 1 %>
+        <%= 2 + 2 %>
+        ```
+      HTML
+      expect(subject.preprocess(html)).to eq(html)
+    end
+
+    it "processes erb outside fence and skips inside fence" do
+      given_html = <<~HTML
+        <%= 1 + 1 %>
+        ```
+        <%= 1 + 1 %>
+        <%= 2 + 2 %>
+        ```
+      HTML
+      processed_html = <<~HTML
+        2
+        ```
+        <%= 1 + 1 %>
+        <%= 2 + 2 %>
+        ```
+      HTML
+      expect(subject.preprocess(given_html)).to eq(processed_html)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

We want ERB to be evaulated in markdown except for inside code fences:

```md
## Hello World

<%= render "component" %>

``ruby
<%= puts "Hello, Ruby!" %>
``
```

## Solution

Converts ERB tags inside code fences to `%%` to avoid processing ERB
inside code fences.

Solution adapted from:
https://stackoverflow.com/questions/65028292/using-regex-to-find-multiple-matches-between-two-strings

Imagine a string like this:

  c x c x A c x c x c B c x c x

Find any "c" character that is between "A" and "B". So in this example I
need to get 3 matches.

Given A and B are different single character strings, use negated
character classes:

(?:\G(?!^)|A)[^AB]*?\Kc(?=[^AB]*B)

See this regex demo. Details:

* (?:\G(?!^)|A) - A or end of the previous successful match
* [^AB]*? - any zero or more chars other than A and B, as few as
  possible
* \K - match reset operator that discards all text matched so far in the
  overall memory match buffer
* c - a c char/string
* (?=[^AB]*B) - that must be followed with zero or more chars other than
  A and B and then B char immediately to the right of the current
location.