### PR TITLE
Randomize specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,6 +84,8 @@ RSpec.configure do |config|
   #   # the seed, which is printed after each run.
   #   #     --seed 1234
   #   config.order = :random
+  config.order = :random
+
   #
   #   # Seed global randomization in this process using the `--seed` CLI option.
   #   # Setting this allows you to use `--seed` to deterministically reproduce


### PR DESCRIPTION
Updates to run rspec tests in random order by default to surface order dependencies. (My preferred setting).

If we find an order dependency and want to debug it, we can fix the order by providing the seed, which is printed after each run.