### PR TITLE
Update solid queue config

### DIFF
--- a/bin/rougify
+++ b/bin/rougify
@@ -5,7 +5,6 @@ require "rouge"
 require "rouge/cli"
 
 require_relative "../lib/rouge/theme/dracula"
-dracula = Rouge::Themes::Dracula
 
 begin
   Rouge::CLI.parse(ARGV).run

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,8 +42,6 @@ module Joy
     # Don't generate system test files.
     config.generators.system_tests = nil
 
-    config.solid_queue.connects_to = {database: {writing: :queue, reading: :queue}}
-
     # Log to STDOUT
     if ENV["RAILS_LOG_TO_STDOUT"] == "true"
       config.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new($stdout))

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,5 +77,8 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :solid_queue
 
+  # Configure the database connection to use for SolidQueue
+  config.solid_queue.connects_to = {database: {writing: :queue, reading: :queue}}
+
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "debug")
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,10 +68,6 @@ Rails.application.configure do
   # Use a different cache store in production.
   config.cache_store = :solid_cache_store
 
-  # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_name_prefix = "joy_production"
-  config.active_job.queue_adapter = :solid_queue
-
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.
@@ -95,6 +91,13 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  # Use a real queuing backend for Active Job (and separate queues per environment).
+  # config.active_job.queue_name_prefix = "joy_production"
+  config.active_job.queue_adapter = :solid_queue
+
+  # Configure the database connection to use for SolidQueue
+  config.solid_queue.connects_to = {database: {writing: :queue, reading: :queue}}
 
   if Rails.version <= "7.1.2"
     config.active_record.sqlite3_production_warning = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -99,7 +99,7 @@ Rails.application.configure do
   # Configure the database connection to use for SolidQueue
   config.solid_queue.connects_to = {database: {writing: :queue, reading: :queue}}
 
-  if Rails.version <= "7.1.2"
+  if Rails.version >= "7.2"
     config.active_record.sqlite3_production_warning = false
   else
     warn "Remove this warning?"

--- a/config/solid_queue.yml
+++ b/config/solid_queue.yml
@@ -1,18 +1,18 @@
-# default: &default
-#   dispatchers:
-#     - polling_interval: 1
-#       batch_size: 500
-#   workers:
-#     - queues: "*"
-#       threads: 5
-#       processes: 1
-#       polling_interval: 0.1
-#
-# development:
-#  <<: *default
-#
-# test:
-#  <<: *default
-#
-# production:
-#  <<: *default
+default: &default
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+  workers:
+    - queues: "*"
+      threads: 5
+      processes: 1
+      polling_interval: 0.1
+
+development:
+ <<: *default
+
+test:
+ <<: *default
+
+production:
+ <<: *default


### PR DESCRIPTION
As part of wasmifying the app, I'd like to limit `config/application.rb` to limit configuration to those settings that apply all environments: development, test, production, and (upcoming) wasm. 

This change moves Solid Queue `connects_to` setting to production and development. We also enable default settings in `config/solid_queue.yml` prior to making future changes.
