### PR TITLE
Switch to cuprite for system tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ end
 group :test do
   gem "capybara" # Acceptance test framework for web applications [https://github.com/teamcapybara/capybara]
   gem "selenium-webdriver" # Ruby bindings for Selenium [https://www.rubydoc.info/gems/selenium-webdriver/frames]
+  gem "cuprite", git: "https://github.com/rubycdp/cuprite"
   gem "webmock", require: false # Library for stubbing HTTP requests [https://github.com/bblimke/webmock]
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/rubycdp/cuprite
+  revision: 9e2788fac70a9d250364ced47a50b77e18fe31a5
+  specs:
+    cuprite (0.15)
+      capybara (~> 3.0)
+      ferrum (~> 0.15.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -171,6 +179,11 @@ GEM
       railties (>= 5.0.0)
     faker (3.2.3)
       i18n (>= 1.8.11, < 2)
+    ferrum (0.15)
+      addressable (~> 2.5)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (~> 0.7)
     flipper (1.2.2)
       concurrent-ruby (< 2)
     flipper-active_record (1.2.2)
@@ -468,6 +481,7 @@ DEPENDENCIES
   brakeman
   bundle-audit
   capybara
+  cuprite!
   debug
   device_detector
   dotenv

--- a/spec/support/system.rb
+++ b/spec/support/system.rb
@@ -1,8 +1,31 @@
+require "capybara/cuprite"
+
+# Default to headless Chrome with Cuprite
+#
+# To run cuprite in Chrome browser
+# HEADLESS=false bin/rspec
+#
+# To run with the inspector, use page.driver.debug in test and run
+# INSPECTOR=true bin/rspec
+
+Capybara.default_max_wait_time = 5
+Capybara.disable_animation = true
+
 RSpec.configure do |config|
   config.include Warden::Test::Helpers, type: :system
   config.include Rails.application.routes.url_helpers, type: :system
 
   config.before(:each, type: :system) do
-    driven_by(:selenium_chrome_headless)
+    driven_by(:cuprite, screen_size: [1440, 810], options: {
+      js_errors: true,
+      headless: %w[0 false].exclude?(ENV["HEADLESS"]),
+      inspector: %w[1 true].include?(ENV["INSPECTOR"]),
+      slowmo: ENV["SLOWMO"]&.to_f,
+      process_timeout: 15,
+      timeout: 10,
+      browser_options: ENV["CI"] ? {"no-sandbox" => nil} : {}
+    })
   end
+
+  config.filter_gems_from_backtrace("capybara", "cuprite", "ferrum")
 end

--- a/spec/system/examples_spec.rb
+++ b/spec/system/examples_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Examples", type: :system do
       click_button "Run"
 
       # Allow extra time for wasm to download and initialize
-      within ".code-output", wait: 20 do
+      within ".code-output", wait: 10 do
         expect(page).to have_text("Hello, Ruby!")
       end
     end


### PR DESCRIPTION
Cuprite removes the overhead of Selenium for interacting with headless Chrome.

This article was helpful in configuring for system tests:

https://janko.io/upgrading-from-selenium-to-cuprite/

<!-- Describe your changes and link to relevant issues or discussions. Please add motivation and context as needed. -->

## Pull request checklist

- [x] I have written tests for code I have added or modified.
- [x] I linted and tested the project with `bin/verify`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
