### PR TITLE
Adopt commonmarker for markdown parsing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "inline_svg" # Embed SVGs in Rails views and style them with CSS [https://gi
 gem "rouge", group: [:default, :wasm] # Pure Ruby syntaix highlighter [https://github.com/rouge-ruby/rouge
 gem "sitepress-rails", group: [:default, :wasm] # Static site generator for Rails [https://sitepress.cc/getting-started/rails]
 gem "phlex-rails", group: [:default, :wasm] # An object-oriented alternative to ActionView for Ruby on Rails. [https://github.com/phlex-ruby/phlex-rails]
-gem "markly"
+gem "commonmarker", require: false
 
 gem "bootsnap", require: false # Reduces boot times through caching; required in config/boot.rb [https://github.com/Shopify/bootsnap]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
     childprocess (5.0.0)
     code_analyzer (0.5.5)
       sexp_processor
+    commonmarker (1.1.2-arm64-darwin)
+    commonmarker (1.1.2-x86_64-linux)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crack (1.0.0)
@@ -264,7 +266,6 @@ GEM
     mail_interceptor (0.0.7)
       activesupport
     marcel (1.0.4)
-    markly (0.10.0)
     matrix (0.4.2)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
@@ -517,6 +518,7 @@ DEPENDENCIES
   brakeman
   bundle-audit
   capybara
+  commonmarker
   cuprite!
   debug
   device_detector
@@ -534,7 +536,6 @@ DEPENDENCIES
   letter_opener
   litestream
   mail_interceptor
-  markly
   mission_control-jobs
   phlex-rails
   puma (>= 5.0)

--- a/app/views/components/markdown/application.rb
+++ b/app/views/components/markdown/application.rb
@@ -1,26 +1,19 @@
 class Markdown::Application < Markdown::Base
-  class Handler
-    class << self
-      def call(template, content)
-        Markdown::Application.new(content).call
-      end
-    end
+  # Options for CommonMarker
+  def default_commonmarker_options
+    {
+      render: {
+        unsafe: true
+      }
+    }
   end
 
   def visit(node)
     return if node.nil?
 
     case node.type
-    in :header
-      header(node.header_level) do
-        visit_children(node)
-      end
-    in :link
-      link(node.url, node.title) { visit_children(node) }
-    in :inline_html
-      unsafe_raw(node.string_content)
-    in :html
-      unsafe_raw(node.string_content)
+    in :html_block
+      unsafe_raw(node.to_html(options: @options))
     else
       super
     end
@@ -40,7 +33,6 @@ class Markdown::Application < Markdown::Base
 
   def code_block(source, metadata = "", **attributes)
     language, json_attributes = parse_code_block_metadata(metadata)
-    Rails.logger.debug("CODE_BLOCK: #{json_attributes.inspect}")
     render CodeBlock.new(source, language: language, **json_attributes, **attributes)
   end
 
@@ -89,5 +81,13 @@ class Markdown::Application < Markdown::Base
         <path d="M4 9h1v1h-1c-1.5 0-3-1.69-3-3.5s1.55-3.5 3-3.5h4c1.45 0 3 1.69 3 3.5 0 1.41-0.91 2.72-2 3.25v-1.16c0.58-0.45 1-1.27 1-2.09 0-1.28-1.02-2.5-2-2.5H4c-0.98 0-2 1.22-2 2.5s1 2.5 2 2.5z m9-3h-1v1h1c1 0 2 1.22 2 2.5s-1.02 2.5-2 2.5H9c-0.98 0-2-1.22-2-2.5 0-0.83 0.42-1.64 1-2.09v-1.16c-1.09 0.53-2 1.84-2 3.25 0 1.81 1.55 3.5 3 3.5h4c1.45 0 3-1.69 3-3.5s-1.5-3.5-3-3.5z"></path>
       </svg>
     SVG
+  end
+
+  class Handler
+    class << self
+      def call(template, content)
+        Markdown::Application.new(content).call
+      end
+    end
   end
 end

--- a/app/views/components/markdown/erb.rb
+++ b/app/views/components/markdown/erb.rb
@@ -2,19 +2,6 @@
 # you trust the source of your markdown and that its not user input.
 
 class Markdown::Erb < Markdown::Application
-  class Handler
-    class << self
-      def call(template, content)
-        content = Markdown::Erb.new(content, flags: Markly::UNSAFE).call
-        erb.call(template, content)
-      end
-
-      def erb
-        @erb ||= ActionView::Template.registered_template_handler(:erb)
-      end
-    end
-  end
-
   ERB_TAGS = %r{s*<%.*?%>}
   ERB_TAGS_START = %r{\A<%.*?%>}
 
@@ -40,6 +27,19 @@ class Markdown::Erb < Markdown::Application
       end
     else
       super
+    end
+  end
+
+  class Handler
+    class << self
+      def call(template, content)
+        content = Markdown::Erb.new(content).call
+        erb.call(template, content)
+      end
+
+      def erb
+        @erb ||= ActionView::Template.registered_template_handler(:erb)
+      end
     end
   end
 end

--- a/app/views/components/markdown/toc.rb
+++ b/app/views/components/markdown/toc.rb
@@ -30,7 +30,7 @@ class Markdown::Toc < Markdown::Base
     case node.type
 
     # collect header nodes in a 2-level hierarchy
-    in :header
+    in :heading
       if @tree.empty? || node.header_level <= 2
         @tree << [node, []]
       elsif node.header_level > 2

--- a/spec/views/components/markdown/erb_spec.rb
+++ b/spec/views/components/markdown/erb_spec.rb
@@ -53,21 +53,21 @@ RSpec.describe Markdown::Erb do
     end
 
     it "handles multiline fenced with multiple erbs" do
-      html = <<~HTML
+      md = <<~MD
         ```
         <%= 1 + 1 %>
         <%= 2 + 2 %>
         ```
-      HTML
-      processed_html = <<~HTML
+      MD
+      html = <<~HTML
         &lt;%= 1 + 1 %&gt;
         &lt;%= 2 + 2 %&gt;
       HTML
-      expect(render(html)).to eq(processed_html)
+      expect(render(md)).to eq(html)
     end
 
     it "handles multiple fences and unfenced areas" do
-      given_html = <<~HTML
+      md = <<~MD
         <%= 1 + 1 %>
         ```
         <%= 2 + 2 %>
@@ -77,13 +77,23 @@ RSpec.describe Markdown::Erb do
         <%= 4 + 4 %>
         ```
         <%= 5 + 5 %>
-      HTML
-      processed_html = <<~HTML.strip
+      MD
+      html = <<~HTML.strip
         <%= 1 + 1 %>&lt;%= 2 + 2 %&gt;
         <%= 3 + 3 %>&lt;%= 4 + 4 %&gt;
         <%= 5 + 5 %>
       HTML
-      expect(render(given_html)).to eq(processed_html)
+      expect(render(md)).to eq(html)
+    end
+
+    it "renders arbitrary html" do
+      md = <<~MD
+        <div>Hello</div>
+      MD
+      html = <<~HTML
+        <div>Hello</div>
+      HTML
+      expect(render(md)).to eq(html)
     end
   end
 end


### PR DESCRIPTION
Replaces markly with commonmarker

Markly is a key piece in the original implementation of the ERB-enhanced markdown rendering in Joy of Rails—adapted from phlex-markdown and built on phlex-ruby.

* https://github.com/ioquatix/markly
* https://github.com/joeldrapper/phlex-markdown

According to the markly README, it was originally created as a fork of commonmarker to get access to the parsed markdown Abstract Syntax Tree (AST). The fork is from before commonmarker switched from being a wrapper of cmark-gfm (implemented in C, gfm = GitHub-flavored markdown) to comrak (Rust port of cmark-gfm), also maintained by awesome maintainers.

* https://github.com/github/cmark-gfm
* https://github.com/kivikakk/comrak

It's been nearly a year since markly was released. Just a few days ago, commonmarker introduced access to its AST meaning it supplies the key feature set to make it compatible for markdown rendering enhancements in Joy of rails.

I checked it out this morning and reported an issue with code fence parsing early today that has already been fixed as of this afternoon—a Saturday no less—in commonmarker v1.1.2.

* Issue:   https://github.com/gjtorikian/commonmarker/issues/289
* Fix:     https://github.com/gjtorikian/commonmarker/pull/290
* Release: https://github.com/gjtorikian/commonmarker/releases/tag/v1.1.2

Performance benchmarks are reported on commonmarker's README. According to these benchmarks, commonmarker outperforms Kramdown by over 25x. markly outperforms commonmarker by roughly 3x.

* https://github.com/gjtorikian/commonmarker?tab=readme-ov-file#benchmarks

That said, this changeset provides the minimum changes to switch from markly to commonmarker for markdown parsing.

Why change? The libs have similar functionality with regards to what Joy of Rails needs at this time. It feels like with commonmarker it is a little easier for me to figure out how to customize the configuration options. Markly's performance outshines commonmarker but not so much for me to say the tradeoff is painful. The energy in the commonmarker and comrak projects is encouraging. I also believe in markly's maintainer, who is awesome, and a terrific advocate for improvements in the Ruby ecosystem.

Ultimately, my choice to switch is more about my perception of the momentum of the respective projects. I have no issues with reconsidering this decision at a later time assuming switching back is comparably straightforward.

<!-- Describe your changes and link to relevant issues or discussions. Please add motivation and context as needed. -->

## Pull request checklist

- [x] I have written tests for code I have added or modified.
- [x] I linted and tested the project with `bin/verify`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
