### PR TITLE
Add http caching headers to sites pages

### DIFF
--- a/app/content/pages/articles/introducing-joy-of-rails.html.mdrb
+++ b/app/content/pages/articles/introducing-joy-of-rails.html.mdrb
@@ -10,7 +10,7 @@ tags:
   - Rails
 ---
 
-## How it started, how it’s going
+## How it started, How it’s going
 
 In 2007, at my first programming job—a software consultancy—a colleague pulled me aside to demo an app he was building. We huddled around one of the office iMacs where I saw a browser, a basic text editor, and a terminal. In his text editor, there was some HTML markup mixed in with some new programming language called Ruby. The terminal was spitting out a screen full of text.
 

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1,0 +1,36 @@
+class SiteController < Sitepress::SiteController
+  # render_resource is a helper method provided by Sitepress to render the current resource.
+  # current_resource is the Sitepress::Resource object that represents the current page.
+  #
+  def show
+    render_resource current_resource
+  end
+
+  protected
+
+  # Hook method provided by Sitepress to process the current "rendition".
+  #
+  # This is to be used by end users if they need to do any post-processing on the rendering page.
+  # For example, the user may use Nokogiri to parse static HTML pages and hook it into the asset pipeline.
+  # They may also use tools like `HTMLPipeline` to process links from a markdown renderer.
+  #
+  # For example, the rendition could be modified via `Nokogiri::HTML5::DocumentFragment(rendition)`.
+  #
+  # @param rendition [Sitepress::Rendition] Rendered representatio of current_resource
+  #
+  def process_rendition(rendition)
+  end
+
+  # Hook method provided by Sitepress to render the page.
+  #
+  # Send the inline rendered, post-processed string into the Rails rendering method that actually sends
+  # the output to the end-user as a web response.
+  #
+  # @param rendition [Sitepress::Rendition] Rendered representatio of current_resource
+  #
+  def post_render(rendition)
+    if stale?(rendition.source, last_modified: current_resource.asset.updated_at.utc, public: true)
+      render body: rendition.output, content_type: rendition.mime_type
+    end
+  end
+end

--- a/config/initializers/rack_mini_profiler.rb
+++ b/config/initializers/rack_mini_profiler.rb
@@ -1,0 +1,3 @@
+if defined?(Rack::MiniProfiler)
+  Rack::MiniProfiler.config.disable_caching = !Rails.application.config.action_controller.perform_caching
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,16 +5,16 @@ Rails.application.routes.draw do
   # Redirects www to root domain
   match "(*any)", to: redirect(subdomain: ""), via: :all, constraints: {subdomain: "www"}
 
+  # Defines the root path route ("/")
+  sitepress_root controller: :site
+
+  sitepress_pages controller: :site
+
   namespace :examples do
     resource :counters, only: [:show, :update, :destroy]
     resource :hello, only: [:show]
   end
   resources :examples, only: [:index, :show]
-
-  sitepress_pages
-
-  # Defines the root path route ("/")
-  sitepress_root
 
   namespace :pwa do
     resource :installation_instructions, only: [:show]

--- a/spec/requests/site_spec.rb
+++ b/spec/requests/site_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe "site: http caching" do
+  let(:file_path) { Rails.root.join("app", "content", "pages", "articles", "introducing-joy-of-rails.html.mdrb") }
+  let(:file) { File.open(file_path) }
+
+  before do
+    allow(Rails.application.config.action_controller).to receive(:perform_caching).and_return(true)
+  end
+
+  def stub_sitepress_asset(updated_at:, body:)
+    allow_any_instance_of(Sitepress::Asset).to receive(:updated_at).and_return(updated_at)
+    allow_any_instance_of(Sitepress::Asset).to receive(:body).and_return(body)
+  end
+
+  def stub_file_updated_at(time)
+  end
+
+  def do_request(headers: {})
+    get "/articles/introducing-joy-of-rails", headers: headers
+  end
+
+  def do_request_with_conditional_get_headers
+    do_request(headers: {
+      "HTTP_IF_NONE_MATCH" => response.headers["ETag"],
+      "HTTP_IF_MODIFIED_SINCE" => response.headers["Last-Modified"]
+    })
+  end
+
+  context "on the first request" do
+    it "returns a 200" do
+      do_request
+
+      expect(response.status).to eq(200)
+    end
+
+    it "sets cache headers" do
+      time = Time.now - 1.day
+      stub_sitepress_asset(updated_at: time, body: "first request body")
+
+      do_request
+
+      expect(response.headers["ETag"]).to be_present
+      expect(response.headers["Last-Modified"]).to eq(time.httpdate)
+    end
+  end
+
+  context "on a subsequent request" do
+    context "if it is not stale" do
+      it "returns a 304" do
+        time = Time.now - 1.day
+        stub_sitepress_asset(updated_at: time, body: "first request body")
+
+        do_request
+        do_request_with_conditional_get_headers
+
+        expect(response.headers["ETag"]).to be_present
+        expect(response.headers["Last-Modified"]).to eq(time.httpdate)
+        expect(response.status).to eq(304)
+      end
+    end
+
+    context "if it has been updated" do
+      it "returns a 200" do
+        first_time = Time.now - 1.day
+        stub_sitepress_asset(updated_at: first_time, body: "first request body")
+
+        do_request
+
+        second_time = Time.now
+        stub_sitepress_asset(updated_at: second_time, body: "second request body")
+
+        do_request_with_conditional_get_headers
+
+        expect(response.headers["ETag"]).to be_present
+        expect(response.headers["Last-Modified"]).to eq(second_time.httpdate)
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Generate override for SiteController provided by sitepress

Uses the `stale?` helper provided by Rails: https://api.rubyonrails.org/v7.1.3/classes/ActionController/ConditionalGet.html#method-i-stale-3F

Adapts test from old gist https://gist.github.com/brettfishman/3868277

<!-- Describe your changes and link to relevant issues or discussions. Please add motivation and context as needed. -->

## Pull request checklist

- [x] I have written tests for code I have added or modified.
- [x] I linted and tested the project with `bin/verify`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
