### PR TITLE
Add admin root page

### DIFF
--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -1,0 +1,4 @@
+class Admin::HomeController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/admin_users/sessions_controller.rb
+++ b/app/controllers/admin_users/sessions_controller.rb
@@ -1,5 +1,5 @@
 class AdminUsers::SessionsController < ApplicationController
-  before_action :redirect_if_authenticated, only: [:create, :new]
+  before_action :redirect_admin_if_authenticated, only: [:create, :new]
 
   def new
   end
@@ -7,14 +7,14 @@ class AdminUsers::SessionsController < ApplicationController
   def create
     warden.authenticate!(:password, scope: :admin_user)
 
-    redirect_to root_path, notice: "Signed in successfully."
+    redirect_to admin_root_path, notice: "Signed in successfully."
   end
 
   def destroy
     warden.logout(:admin_user)
     warden.clear_strategies_cache!(scope: :admin_user)
 
-    redirect_to root_path, notice: "Signed out successfully."
+    redirect_to new_admin_users_session_path, notice: "Signed out successfully."
   end
 
   def fail

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -12,8 +12,8 @@ module Authentication
     request.env["warden"]
   end
 
-  def redirect_if_authenticated
-    redirect_to root_path, alert: "You are already logged in." if admin_user_signed_in?
+  def redirect_admin_if_authenticated
+    redirect_to admin_root_path, alert: "You are already logged in." if admin_user_signed_in?
   end
 
   protected

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -1,0 +1,15 @@
+<div class="container">
+  <div class="row">
+    <header class="col-md-12">
+      <h1>Admin</h1>
+    </header>
+
+    <div class="col-md-12">
+      <ul>
+        <li><a href="/admin/flipper">Flipper</a></li>
+        <li><a href="/admin/roles">Roles</a></li>
+        <li><a href="/admin/permissions">Permissions</a></li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -1,15 +1,43 @@
 <div class="container">
   <div class="row">
-    <header class="col-md-12">
-      <h1>Admin</h1>
-    </header>
-
-    <div class="col-md-12">
-      <ul>
-        <li><a href="/admin/flipper">Flipper</a></li>
-        <li><a href="/admin/roles">Roles</a></li>
-        <li><a href="/admin/permissions">Permissions</a></li>
-      </ul>
-    </div>
+    <section class="max-w-screen-lg py-16 mx-auto lg:py-20">
+      <h1 class="pb-16 text-2xl font-bold text-center md:text-4xl">Admin</h1>
+    </section>
   </div>
+  <ul role="list" class="divide-y divide-gray-100">
+    <li class="relative flex py-5">
+      <div class="flex min-w-0 gap-x-4">
+        <div class="min-w-0 flex-auto">
+          <p class="font-semibold leading-6">
+            <a href="/admin/flipper">
+              <span class="absolute inset-x-0 -top-px bottom-0"></span>
+              Flipper
+            </a>
+          </p>
+        </div>
+      </div>
+      <div class="flex shrink-0 items-center gap-x-4">
+        <svg class="h-5 w-5 flex-none text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
+        </svg>
+      </div>
+    </li>
+    <li class="relative flex py-5">
+      <div class="flex min-w-0 gap-x-4">
+        <div class="min-w-0 flex-auto">
+          <p class="font-semibold leading-6">
+            <a href="/admin/jobs">
+              <span class="absolute inset-x-0 -top-px bottom-0"></span>
+              Mission Control Jobs
+            </a>
+          </p>
+        </div>
+      </div>
+      <div class="flex shrink-0 items-center gap-x-4">
+        <svg class="h-5 w-5 flex-none text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
+        </svg>
+      </div>
+    </li>
+  </ul>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,8 @@ Rails.application.routes.draw do
 
   unless Rails.env.wasm?
     scope :admin, constraints: Routes::AdminAccessConstraint.new do
+      root to: "admin/home#index", as: :admin_root
+
       mount Flipper::UI.app(Flipper) => "/flipper"
       mount MissionControl::Jobs::Engine, at: "/jobs"
     end


### PR DESCRIPTION
When signing in as an admin, we'll now redirect to the admin index page, which contains links to the admin engines like jobs and flipper flags. While itself useful, this also is added to side-step the fact that Site pages will now have HTTP caching, so flash messages will not work out-of-the-box on these pages. We could potentially do something with turbo + flash, but punt on that for now.

## Pull request checklist

- [x] I have written tests for code I have added or modified.
- [x] I linted and tested the project with `bin/verify`
