### PR TITLE
Render code block for app file from revision

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -59,6 +59,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1

--- a/app/content/pages/articles/introducing-joy-of-rails.html.mdrb
+++ b/app/content/pages/articles/introducing-joy-of-rails.html.mdrb
@@ -86,7 +86,7 @@ Let’s say I wanted to describe how to build a basic counter with Rails and Hot
 
 I can also link to and embed the code that makes this work, like the <%= link_to_app_file("app/controllers/examples/counters_controller.rb", "counters controller") %> that saves the count in your session and renders the HTML for this counter dynamically:
 
-<%= render CodeBlock::AppFile.new("app/controllers/examples/counters_controller.rb", language: "ruby") %>
+<%= render CodeBlock::AppFile.new("app/controllers/examples/counters_controller.rb", language: "ruby", revision: "504f449e34232fc5299da78056344fffe04460de") %>
 
 It would be harder to accomplish this with a WordPress blog or static website.
 

--- a/app/models/examples/app_file.rb
+++ b/app/models/examples/app_file.rb
@@ -12,33 +12,32 @@ module Examples
         new(path)
       end
 
-      def from(path)
+      def from(path, **)
         case path
-        when AppFile
-          path
-        when File
-          new(path.path)
+        when AppFile, File
+          new(path.path, **)
         when String, Pathname
-          new(path)
+          new(path, **)
         else
           raise ArgumentError, "Invalid AppFile path: #{path.inspect}"
         end
       end
     end
 
-    attr_reader :path
+    attr_reader :path, :revision
     alias_method :filename, :path
 
-    def initialize(path)
+    def initialize(path, revision: "HEAD")
       @path = path
+      @revision = revision
     end
 
     def readlines
-      File.readlines(@path)
+      read.scan(%r{.*\n})
     end
 
     def read
-      File.read(@path)
+      `git show #{@revision}:#{@path}`.strip
     end
     alias_method :content, :read
     alias_method :source, :read
@@ -57,8 +56,7 @@ module Examples
     alias_method :extension, :extname
 
     def repo_url
-      branch = `git rev-parse --abbrev-ref HEAD`
-      "https://github.com/joyofrails/joyofrails.com/blob/#{branch}/#{app_path}"
+      "https://github.com/joyofrails/joyofrails.com/blob/#{revision}/#{app_path}"
     end
   end
 end

--- a/app/views/components/code_block/app_file.rb
+++ b/app/views/components/code_block/app_file.rb
@@ -4,9 +4,8 @@ class CodeBlock::AppFile < Phlex::HTML
   # @param filename [String] the file path or an Examples::AppFile.
   # @param file [String] the file path or an Examples::AppFile.
   def initialize(filename, lines: nil, revision: nil, **attributes)
-    @app_file = Examples::AppFile.from(filename)
+    @app_file = Examples::AppFile.from(filename, revision: revision)
     @lines = lines
-    @revision = revision
     @attributes = attributes
   end
 

--- a/app/views/components/code_block/app_file.rb
+++ b/app/views/components/code_block/app_file.rb
@@ -10,7 +10,7 @@ class CodeBlock::AppFile < Phlex::HTML
   end
 
   def view_template
-    render ::CodeBlock::Article.new("", **attributes) do |code_block|
+    render ::CodeBlock::Article.new(**attributes) do |code_block|
       code_block.title do
         a(href: app_file.repo_url, target: "_blank", class: "not-prose flex items-center gap-1") {
           plain app_file.filename

--- a/app/views/components/code_block/app_file.rb
+++ b/app/views/components/code_block/app_file.rb
@@ -33,7 +33,7 @@ class CodeBlock::AppFile < CodeBlock
 
     content = if lines.present?
       readlines = app_file.readlines
-      lines = lines.map { |e| [*e] }.flatten
+      lines = lines.map { |e| [*e] }.flatten.map(&:to_i).map { |e| e - 1 }
 
       readlines.values_at(*lines).join.strip
     else

--- a/app/views/components/code_block/app_file.rb
+++ b/app/views/components/code_block/app_file.rb
@@ -1,30 +1,35 @@
-class CodeBlock::AppFile < CodeBlock
+class CodeBlock::AppFile < Phlex::HTML
+  include InlineSvg::ActionView::Helpers
+
+  # @param filename [String] the file path or an Examples::AppFile.
   # @param file [String] the file path or an Examples::AppFile.
-  def initialize(filename, lines: nil, **attributes)
+  def initialize(filename, lines: nil, revision: nil, **attributes)
     @app_file = Examples::AppFile.from(filename)
     @lines = lines
-    source = nil
-    super(source, **attributes)
+    @revision = revision
+    @attributes = attributes
   end
 
   def view_template
-    super { read_file }
-  end
+    render ::CodeBlock::Article.new("", **attributes) do |code_block|
+      code_block.title do
+        a(href: app_file.repo_url, target: "_blank", class: "not-prose flex items-center gap-1") {
+          plain app_file.filename
+          plain inline_svg_tag("external-link.svg", class: "icon icon-sm", height: 12, width: 12)
+        }
+      end
 
-  def title_content
-    a(href: app_file.repo_url, target: "_blank", class: "not-prose flex items-center gap-1") {
-      plain title
-      plain inline_svg_tag("external-link.svg", class: "icon icon-sm", height: 12, width: 12)
-    }
+      code_block.source_code do
+        read_file
+      end
+    end
   end
 
   private
 
-  attr_reader :app_file
+  attr_reader :app_file, :attributes
 
   def path = app_file.path
-
-  def filename = app_file.filename
 
   def read_file
     file = Rails.root.join(*path)
@@ -35,11 +40,11 @@ class CodeBlock::AppFile < CodeBlock
       readlines = app_file.readlines
       lines = lines.map { |e| [*e] }.flatten.map(&:to_i).map { |e| e - 1 }
 
-      readlines.values_at(*lines).join.strip
+      readlines.values_at(*lines).join
     else
       file.read
     end
 
-    content.html_safe
+    content.strip.html_safe
   end
 end

--- a/app/views/components/code_block/basic.rb
+++ b/app/views/components/code_block/basic.rb
@@ -1,0 +1,33 @@
+class CodeBlock::Basic < Phlex::HTML
+  class << self
+    def code_formatter
+      @code_formatter ||= Rouge::Formatters::HTML.new
+    end
+  end
+
+  def initialize(source = nil, language: nil, data: {})
+    @source = source
+    @language = language
+    @data = data
+  end
+
+  def view_template(&block)
+    pre do
+      code data: data do
+        unsafe_raw self.class.code_formatter.format(lexer.lex(source))
+      end
+    end
+  end
+
+  protected
+
+  private
+
+  attr_reader :source, :language, :data
+
+  def code_formatter
+    self.class.code_formatter
+  end
+
+  def lexer = Rouge::Lexer.find(language) || Rouge::Lexers::PlainText
+end

--- a/app/views/components/markdown/application.rb
+++ b/app/views/components/markdown/application.rb
@@ -33,7 +33,7 @@ class Markdown::Application < Markdown::Base
 
   def code_block(source, metadata = "", **attributes)
     language, json_attributes = parse_code_block_metadata(metadata)
-    render CodeBlock.new(source, language: language, **json_attributes, **attributes)
+    render ::CodeBlock::Article.new(source, language: language, **json_attributes, **attributes)
   end
 
   def link(url, title, **attrs, &)

--- a/app/views/examples/_example.html.erb
+++ b/app/views/examples/_example.html.erb
@@ -1,4 +1,4 @@
 <div id="example_<%= example.basename(".*") %>">
-  <%= render CodeBlock.new(example.source, language: "ruby", filename: example.app_path, run: true) %>
+  <%= render CodeBlock::AppFile.new(example.app_path, language: "ruby", run: true) %>
   <%= link_to "Source", example.repo_url %>
 </div>

--- a/app/views/examples/counters/_counter.html.erb
+++ b/app/views/examples/counters/_counter.html.erb
@@ -1,7 +1,7 @@
 <div class="not-prose mx-auto max-w-7xl">
   <div class="grid grid-cols-1 gap-px sm:grid-cols-2">
     <div>
-      <div class="bg-[var(--dracula-black)] rounded-md px-4 py-6 sm:px-6 lg:px-8">
+      <div class="bg-[var(--dracula-bg)] rounded-md px-4 py-6 sm:px-6 lg:px-8">
         <p class="text-sm font-medium leading-6 text-gray-400">Count</p>
         <p class="mt-2 flex items-baseline gap-x-2">
           <span class="text-4xl font-semibold tracking-tight text-white"><%= counter.count %></span>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,29 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "7297db165692a1744273cd4c5f755daee483c999bf28b7cce39ff84ca9c3a64f",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/models/examples/app_file.rb",
+      "line": 40,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "`git show #{@revision}:#{@path}`",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Examples::AppFile",
+        "method": "read"
+      },
+      "user_input": "@revision",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
+      ],
+      "note": "We mark this warning as ignored since we expect to only run this code on app files and not on user-generated content."
+    }
+  ],
+  "updated": "2024-05-09 20:09:09 -0400",
+  "brakeman_version": "6.1.2"
+}

--- a/spec/models/examples/app_file_spec.rb
+++ b/spec/models/examples/app_file_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Examples::AppFile, type: :model do
+  describe "with path" do
+    subject { described_class.from("config/database.yml") }
+
+    it { expect(subject.app_path).to eq("config/database.yml") }
+
+    it { expect(subject.read).to be =~ %r{adapter: sqlite3} }
+    it { expect(subject.readlines).to include(%r{adapter: sqlite3}) }
+    it { expect(subject.readlines.count).to be > 20 }
+
+    it { expect(subject.basename).to eq("database.yml") }
+
+    it { expect(subject.extname).to eq(".yml") }
+
+    it { expect(subject.repo_url).to eq("https://github.com/joyofrails/joyofrails.com/blob/HEAD/config/database.yml") }
+  end
+
+  describe "with path from revision" do
+    subject { described_class.from("config/database.yml", revision: "bfe2f6a1fa") }
+
+    it { expect(subject.app_path).to eq("config/database.yml") }
+
+    it { expect(subject.read).to be =~ %r{adapter: litedb} }
+    it { expect(subject.readlines).to include(%r{adapter: litedb}) }
+    it { expect(subject.readlines.count).to be > 20 }
+
+    it { expect(subject.basename).to eq("database.yml") }
+
+    it { expect(subject.extname).to eq(".yml") }
+
+    it { expect(subject.repo_url).to eq("https://github.com/joyofrails/joyofrails.com/blob/bfe2f6a1fa/config/database.yml") }
+  end
+end

--- a/spec/views/components/code_block/app_file_spec.rb
+++ b/spec/views/components/code_block/app_file_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe CodeBlock::AppFile, type: :view do
+  def render_page(*, **)
+    Capybara.string(render(*, **))
+  end
+
+  it "renders contents of file" do
+    page = render_page(CodeBlock::AppFile.new("config/database.yml"))
+    expect(page).to have_content(<<~YAML)
+      default: &default
+        adapter: sqlite3
+    YAML
+  end
+
+  it "renders contents of file by line number" do
+    page = render_page(CodeBlock::AppFile.new("config/database.yml", lines: 7))
+    expect(page).to have_content(<<~YAML.strip)
+      default: &default
+    YAML
+
+    expect(page).not_to have_content("database: storage/production/data.sqlite3")
+  end
+
+  it "renders contents of file by line number range" do
+    page = render_page(CodeBlock::AppFile.new("config/database.yml", lines: [7..8]))
+    expect(page).to have_content(<<~YAML.strip)
+      default: &default
+        adapter: sqlite3
+    YAML
+
+    expect(page).not_to have_content("database: storage/production/data.sqlite3")
+  end
+
+  it "renders contents of file by heterogeneous line number collection" do
+    page = render_page(CodeBlock::AppFile.new("config/database.yml", lines: [7..8, 51]))
+    expect(page).to have_content(<<~YAML.strip)
+      default: &default
+        adapter: sqlite3
+    YAML
+
+    expect(page).to have_content("database: storage/production/data.sqlite3")
+    expect(page).not_to have_content("database: storage/development/data.sqlite3")
+  end
+end

--- a/spec/views/components/code_block/basic_spec.rb
+++ b/spec/views/components/code_block/basic_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe CodeBlock::Basic, type: :view do
+  def render_page(*, **)
+    Capybara.string(render(*, **))
+  end
+
+  it "renders contents of file" do
+    page = render_page(CodeBlock::Basic.new("def ruby = 'awesome'", language: "ruby"))
+    expect(page).to have_content("def ruby = 'awesome'")
+  end
+end

--- a/spec/views/components/markdown/erb_spec.rb
+++ b/spec/views/components/markdown/erb_spec.rb
@@ -18,12 +18,11 @@ RSpec.describe Markdown::Erb do
     end
 
     before do
-      stub_const("CodeBlock", code_block_class)
+      stub_const("CodeBlock::Article", code_block_class)
     end
 
     def render(content, &block)
-      view = Markdown::Erb.new(content)
-      view.call(view_context: nil, &block)
+      Markdown::Erb.new(content).call(&block)
     end
 
     it "processes text" do

--- a/spec/views/components/markdown/toc_spec.rb
+++ b/spec/views/components/markdown/toc_spec.rb
@@ -1,12 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Markdown::Toc do
-  include Phlex::Testing::ViewHelper
-
-  def squish_html(html)
-    html.gsub(/\n+/, "").gsub(/>\s+</, "><").gsub(/^\s+/, "")
-  end
-
   it "renders nothing for a markdown document without headers" do
     output = render(Markdown::Toc.new(<<~MD))
       Hello
@@ -67,5 +61,9 @@ RSpec.describe Markdown::Toc do
         </li>
       </ul>
     HTML
+  end
+
+  def squish_html(html)
+    html.gsub(/\n+/, "").gsub(/>\s+</, "><").gsub(/^\s+/, "")
   end
 end


### PR DESCRIPTION
An app file can change over time so rendering the source of an app file from disk into the view can break expectations if given line numbers don't line up.

Now we render app files from git revision instead of from a file read. If no revision given, the revision will point to HEAD.