### PR TITLE
Add solid cable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,9 +289,9 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.1)
-    nokogiri (1.16.4-arm64-darwin)
+    nokogiri (1.16.5-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.4-x86_64-linux)
+    nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
     openssl (3.2.0)
     parallel (1.24.0)

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,25 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    rescue_from StandardError, with: :report_error
+
+    identified_by :current_admin_user
+
+    def connect
+      self.current_admin_user = find_verified_admin_user
+      logger.add_tags "ActionCable", current_admin_user.id
+    end
+
+    private
+
+    def find_verified_admin_user
+      env["warden"].user(scope: :admin_user) || reject_unauthorized_connection
+    end
+
+    private
+
+    def report_error(e)
+      Rails.logger.error(e)
+      Honeybadger.notify(e)
+    end
   end
 end

--- a/app/channels/heartbeat_channel.rb
+++ b/app/channels/heartbeat_channel.rb
@@ -1,0 +1,8 @@
+class HeartbeatChannel < ApplicationCable::Channel
+  def subscribed
+    stream_for current_admin_user
+  end
+
+  def unsubscribed
+  end
+end

--- a/app/javascript/channels/consumer.js
+++ b/app/javascript/channels/consumer.js
@@ -1,0 +1,6 @@
+// Action Cable provides the framework to deal with WebSockets in Rails.
+// You can generate new channels where WebSocket features live using the `bin/rails generate channel` command.
+
+import { createConsumer } from "@rails/actioncable"
+
+export default createConsumer()

--- a/app/javascript/channels/heartbeat-channel.js
+++ b/app/javascript/channels/heartbeat-channel.js
@@ -1,0 +1,13 @@
+import consumer from './consumer';
+import debug from '../utils/debug';
+
+const console = debug('app:javascript:channels:heartbeat-channel');
+
+export const subscribe = () => {
+  consumer.subscriptions.create('HeartbeatChannel', {
+    received(data) {
+      console.log('received', data);
+      new Notification(data['title'], { body: data['body'] });
+    },
+  });
+};

--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,0 +1,2 @@
+// Import all the channels to be used by Action Cable
+export * as heartbeat from './heartbeat-channel';

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -3,12 +3,12 @@ import debug from 'debug';
 import '@hotwired/turbo-rails';
 import '../controllers';
 
-import railsWasmUrl from '../ruby-wasm/rails/url';
-
 import {
   turboScrollSmoothWorkaround,
   registerServiceWorker,
 } from '../initializers';
+
+import * as channels from '../channels';
 
 const log = debug('app:javascript:entrypoints:application');
 // To see this message, add the following to the `<head>` section in your
@@ -46,4 +46,4 @@ log('Vite ⚡️ Rails');
 registerServiceWorker();
 turboScrollSmoothWorkaround();
 
-console.log('railsWasmUrl', railsWasmUrl);
+window.channels = channels;

--- a/app/jobs/channels/heartbeat_job.rb
+++ b/app/jobs/channels/heartbeat_job.rb
@@ -1,0 +1,12 @@
+class Channels::HeartbeatJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    AdminUser.find_each do |admin_user|
+      HeartbeatChannel.broadcast_to \
+        admin_user,
+        title: "It’s alive!",
+        body: "The Action Cable connection is working!"
+    end
+  end
+end

--- a/app/models/solid_cable/message.rb
+++ b/app/models/solid_cable/message.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module SolidCable
+  class Message < SolidCable::Record
+    scope :prunable, lambda {
+      where(created_at: ..::SolidCable.keep_messages_around_for.ago)
+    }
+    scope :broadcastable, lambda { |channels, last_id|
+      where(channel: channels).where(id: (last_id + 1)..).order(:id)
+    }
+
+    def self.prune
+      prunable.delete_all
+    end
+  end
+end

--- a/app/models/solid_cable/record.rb
+++ b/app/models/solid_cable/record.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SolidCable
+  class Record < ActiveRecord::Base
+    self.abstract_class = true
+
+    connects_to(**SolidCable.connects_to) if SolidCable.connects_to
+  end
+end

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -41,3 +41,12 @@
     </li>
   </ul>
 </div>
+
+<script type="text/javascript">
+  document.addEventListener("DOMContentLoaded", () => {
+    if (window.channels?.heartbeat?.subscribe) {
+      console.log('Subscribing to Action Cable heartbeat channel');
+      window.channels.heartbeat.subscribe();
+    }
+  });
+</script>

--- a/config/application.rb
+++ b/config/application.rb
@@ -55,5 +55,8 @@ module Joy
     # Configure Postmark
     config.action_mailer.delivery_method = :postmark
     config.action_mailer.postmark_settings = {api_token: Rails.application.credentials.postmark&.api_token || "POSTMARK_API_TEST"}
+
+    # Set up solid cable options
+    config.solid_cable = ActiveSupport::OrderedOptions.new
   end
 end

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,8 +1,13 @@
 development:
-  adapter: async
+  adapter: solid_cable
+  silence_polling: true
+  polling_interval: 1
+  keep_messages_around_for: 30.minutes
 
 test:
   adapter: test
 
 production:
-  adapter: async
+  adapter: solid_cable
+  polling_interval: 0.1
+  keep_messages_around_for: 10.minutes

--- a/config/database.yml
+++ b/config/database.yml
@@ -41,7 +41,10 @@ test:
     <<: *default
     database: storage/test/queue.sqlite3
     migrations_paths: db/migrate_queue
-
+  cable:
+    <<: *default
+    database: storage/test/cable.sqlite3
+    migrations_paths: db/migrate_cable
 
 # SQLite3 write its data on the local filesystem, as such it requires
 # persistent disks. If you are deploying to a managed service, you should

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,6 +21,10 @@ development:
     <<: *default
     database: storage/development/queue.sqlite3
     migrations_paths: db/migrate_queue
+  cable:
+    <<: *default
+    database: storage/development/cable.sqlite3
+    migrations_paths: db/migrate_cable
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -57,6 +61,9 @@ production:
     <<: *default
     database: storage/production/queue.sqlite3
     migrations_paths: db/migrate_queue
+  cable:
+    database: storage/production/cable.sqlite3
+    migrations_paths: db/migrate_cable
 
 wasm:
   adapter: nulldb

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,5 +82,7 @@ Rails.application.configure do
   # Configure the database connection to use for SolidQueue
   config.solid_queue.connects_to = {database: {writing: :queue, reading: :queue}}
 
+  config.solid_cable.connects_to = {database: {writing: :cable, reading: :cable}}
+
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "debug")
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,6 +100,8 @@ Rails.application.configure do
   # Configure the database connection to use for SolidQueue
   config.solid_queue.connects_to = {database: {writing: :queue, reading: :queue}}
 
+  config.solid_cable.connects_to = {database: {writing: :cable, reading: :cable}}
+
   if Rails.version >= "7.2"
     warn "Remove the sqlite in production check?"
   else

--- a/config/initializers/solid_cable.rb
+++ b/config/initializers/solid_cable.rb
@@ -1,0 +1,3 @@
+require "solid_cable"
+
+SolidCable.connects_to = {database: {writing: :cable, reading: :cable}}

--- a/config/initializers/solid_cable.rb
+++ b/config/initializers/solid_cable.rb
@@ -1,3 +1,5 @@
 require "solid_cable"
 
-SolidCable.connects_to = {database: {writing: :cable, reading: :cable}}
+Rails.application.config.solid_cable.each do |name, value|
+  SolidCable.public_send(:"#{name}=", value)
+end

--- a/db/cable_schema.rb
+++ b/db/cable_schema.rb
@@ -1,0 +1,21 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2024_05_14_132951) do
+  create_table "solid_cable_messages", force: :cascade do |t|
+    t.text "channel"
+    t.text "payload"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
+  end
+end

--- a/db/migrate_cable/20240514132951_create_solid_cable_messages.rb
+++ b/db/migrate_cable/20240514132951_create_solid_cable_messages.rb
@@ -1,0 +1,12 @@
+class CreateSolidCableMessages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :solid_cable_messages, if_not_exists: true do |t|
+      t.text :channel
+      t.text :payload
+
+      t.timestamps
+
+      t.index :created_at
+    end
+  end
+end

--- a/lib/action_cable/subscription_adapter/solid_cable.rb
+++ b/lib/action_cable/subscription_adapter/solid_cable.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module ActionCable
+  module SubscriptionAdapter
+    class SolidCable < Base
+      prepend ChannelPrefix
+
+      def initialize(*)
+        super
+        @listener = nil
+      end
+
+      def broadcast(channel, payload)
+        ::SolidCable::Message.create(channel:, payload:)
+      end
+
+      def subscribe(channel, callback, success_callback = nil)
+        listener.add_subscriber(channel, callback, success_callback)
+      end
+
+      def unsubscribe(channel, callback)
+        listener.remove_subscriber(channel, callback)
+      end
+
+      delegate :shutdown, to: :listener
+
+      private
+
+      def listener
+        @listener || @server.mutex.synchronize do
+          @listener ||= Listener.new(@server.event_loop)
+        end
+      end
+
+      class Listener < SubscriberMap
+        def initialize(event_loop)
+          super()
+
+          @event_loop = event_loop
+
+          @thread = Thread.new do
+            Thread.current.abort_on_exception = true
+            listen
+          end
+        end
+
+        def listen
+          while running?
+            with_polling_volume { broadcast_messages }
+
+            sleep ::SolidCable.polling_interval
+          end
+        end
+
+        def shutdown
+          self.running = false
+          Thread.pass while thread.alive?
+        end
+
+        def add_channel(channel, on_success)
+          channels.add(channel)
+          event_loop.post(&on_success) if on_success
+        end
+
+        def remove_channel(channel)
+          channels.delete(channel)
+
+          ::SolidCable::Message.prune
+        end
+
+        def invoke_callback(*)
+          event_loop.post { super }
+        end
+
+        private
+
+        attr_reader :event_loop, :thread
+        attr_writer :running, :last_id
+
+        def running?
+          if defined?(@running)
+            @running
+          else
+            self.running = true
+          end
+        end
+
+        def last_id
+          @last_id ||= ::SolidCable::Message.maximum(:id) || 0
+        end
+
+        def channels
+          @channels ||= Set.new
+        end
+
+        def broadcast_messages
+          ::SolidCable::Message.broadcastable(channels, last_id)
+            .each do |message|
+              broadcast(message.channel, message.payload)
+              self.last_id = message.id
+            end
+        end
+
+        def with_polling_volume
+          if ::SolidCable.silence_polling?
+            ActiveRecord::Base.logger.silence { yield }
+          else
+            yield
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/solid_cable.rb
+++ b/lib/solid_cable.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "solid_cable/engine"
+require "action_cable/subscription_adapter/solid_cable"
+
+module SolidCable
+  mattr_accessor :connects_to
+
+  def self.silence_polling?
+    !!Rails.application.config_for("cable")[:silence_polling]
+  end
+
+  def self.polling_interval
+    Rails.application.config_for("cable")[:polling_interval].presence || 0.1
+  end
+
+  def self.keep_messages_around_for
+    duration = Rails.application.config_for("cable")[:keep_messages_around_for]
+
+    if duration.present?
+      amount, units = duration.to_s.split(".")
+      amount.to_i.public_send(units)
+    else
+      30.minutes
+    end
+  end
+end

--- a/lib/solid_cable/engine.rb
+++ b/lib/solid_cable/engine.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidCable
+  class Engine < ::Rails::Engine
+    isolate_namespace SolidCable
+
+    config.solid_cable = ActiveSupport::OrderedOptions.new
+
+    initializer "solid_cable.config" do
+      config.solid_cable.each do |name, value|
+        SolidCable.public_send(:"#{name}=", value)
+      end
+    end
+  end
+end

--- a/lib/tasks/channels/heartbeart.rake
+++ b/lib/tasks/channels/heartbeart.rake
@@ -1,0 +1,5 @@
+namespace :channels do
+  task heartbeat: :environment do
+    Channels::HeartbeatJob.perform_now
+  end
+end

--- a/spec/views/components/code_block/app_file_spec.rb
+++ b/spec/views/components/code_block/app_file_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CodeBlock::AppFile, type: :view do
   end
 
   it "renders contents of file by heterogeneous line number collection" do
-    page = render_page(CodeBlock::AppFile.new("config/database.yml", lines: [7..8, 51]))
+    page = render_page(CodeBlock::AppFile.new("config/database.yml", lines: [7..8, 58]))
     expect(page).to have_content(<<~YAML.strip)
       default: &default
         adapter: sqlite3


### PR DESCRIPTION
This PR inlines [SolidCable](https://github.com/npezza93/solid_cable), a SQLite-compatible Rails adapter for ActionCable.

With this change, SQLite is officially the backend for the major Rails persistence components, including ActiveRecord, ActionCable, caching, and job queues.

I inlined the gem as an opportunity to learn more about ActionCable. Full credit to the original author @ npezza93.

I've also added a heartbeat channel as a method of verifying the integration is working in production.