### PR TITLE
Fix missing config in prod database.yml

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -65,6 +65,7 @@ production:
     database: storage/production/queue.sqlite3
     migrations_paths: db/migrate_queue
   cable:
+    <<: *default
     database: storage/production/cable.sqlite3
     migrations_paths: db/migrate_cable
 


### PR DESCRIPTION
After merging #135, the production deploy failed on `bin/rails db:migrate` with the following error:

```
ActiveRecord::AdapterNotSpecified: database configuration does not specify adapter (ActiveRecord::AdapterNotSpecified)
```

The production section of `database.yml` for `cable` was missing the default config, now addressed with this change.