### PR TITLE
Add RSS feed

### DIFF
--- a/app/content/pages/articles/web-push-notifications-from-rails.html.mdrb
+++ b/app/content/pages/articles/web-push-notifications-from-rails.html.mdrb
@@ -100,7 +100,7 @@ for push subscriptions and notifications.
 
 Here's an example from [Joy of Rails](/manifest.json):
 
-```json:manifest.json
+```json
 {
   "name": "Joy of Rails",
   "start_url": "/",
@@ -121,7 +121,7 @@ Here's an example from [Joy of Rails](/manifest.json):
   "background_color": "#FFFFFF",
   "display": "standalone",
   "orientation": "portrait",
-  "author": "Ross Kaffenberger",
+  "author": "Ross Kaffenberger"
 }
 ```
 

--- a/app/controllers/feed_controller.rb
+++ b/app/controllers/feed_controller.rb
@@ -1,0 +1,4 @@
+class FeedController < ApplicationController
+  def index
+  end
+end

--- a/app/views/components/code_block/article.rb
+++ b/app/views/components/code_block/article.rb
@@ -56,7 +56,7 @@ class CodeBlock::Article < Phlex::HTML
   end
 
   def title_content
-    @title || -> { filename || language }
+    @title || ->(*) { filename || language }
   end
 
   protected

--- a/app/views/feed/index.xml.builder
+++ b/app/views/feed/index.xml.builder
@@ -1,0 +1,18 @@
+xml.instruct! :xml, version: "1.0"
+xml.rss version: "2.0" do
+  xml.channel do
+    xml.title "Joy of Rails"
+    xml.description "Tutorials and tips that capture the joy of building web applications with Ruby on Rails"
+    xml.link root_url
+
+    ArticlePage.published.take(10).each do |page|
+      xml.item do
+        xml.title page.data.title
+        xml.description Markdown::Erb.new(page.body).call
+        xml.pubDate page.published_on.to_formatted_s(:rfc822)
+        xml.link request.base_url + page.request_path
+        xml.guid request.base_url + page.request_path
+      end
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,9 @@
     <%= vite_client_tag %>
     <%= vite_stylesheet_tag "application.css", media: "all", "data-turbo-track": "reload" %>
     <%= vite_javascript_tag "application.js", media: "all", "data-turbo-track": "reload" %>
+
+    <%= auto_discovery_link_tag(:rss, feed_index_url, {title: "joyofrails.com"}) %>
+
     <script type="text/javascript" defer data-domain="joyofrails.com" src="https://plausible.io/js/script.tagged-events.outbound-links.js"></script>
     <script type="text/javascript">window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,6 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   sitepress_root controller: :site
-
   sitepress_pages controller: :site
 
   namespace :examples do
@@ -20,6 +19,8 @@ Rails.application.routes.draw do
     resource :installation_instructions, only: [:show]
     resources :web_pushes, only: [:create]
   end
+
+  resources :feed, only: [:index], format: "xml"
 
   # Render dynamic PWA files from app/views/pwa/*
   get "serviceworker" => "rails/pwa#serviceworker", :as => :pwa_serviceworker, :constraints => {format: "js"}

--- a/spec/requests/feed_spec.rb
+++ b/spec/requests/feed_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "Feed", type: :request do
+  describe "GET /feed" do
+    it "renders" do
+      get "/feed"
+
+      expect(response.status).to eq(200)
+      page = Capybara.string(response.body)
+
+      expect(page).to have_content("Introducing Joy of Rails")
+      expect(page).to have_content("/introducing-joy-of-rails")
+      expect(page).to have_content("<h2>How it started, How it’s going</h2>")
+    end
+  end
+end


### PR DESCRIPTION
I've added `/feed` to provide RSS-based XML feed for recent articles.

This is also the first time I've learned about `auto_discovery_link_tag` so readers can find the URL.

https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-auto_discovery_link_tag