### PR TITLE
Fix for solid cable config eager loading in production

### DIFF
--- a/config/application_wasm.rb
+++ b/config/application_wasm.rb
@@ -54,5 +54,7 @@ module Joy
     if ENV["RAILS_LOG_TO_STDOUT"] == "true"
       config.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new($stdout))
     end
+
+    config.solid_cable = ActiveSupport::OrderedOptions.new
   end
 end

--- a/lib/solid_cable/engine.rb
+++ b/lib/solid_cable/engine.rb
@@ -4,12 +4,15 @@ module SolidCable
   class Engine < ::Rails::Engine
     isolate_namespace SolidCable
 
-    config.solid_cable = ActiveSupport::OrderedOptions.new
+    # Engine configuration moved to initializer to allow for
+    # lazy loading in development
 
-    initializer "solid_cable.config" do
-      config.solid_cable.each do |name, value|
-        SolidCable.public_send(:"#{name}=", value)
-      end
-    end
+    # config.solid_cable = ActiveSupport::OrderedOptions.new
+
+    # initializer "solid_cable.config" do
+    #   config.solid_cable.each do |name, value|
+    #     SolidCable.public_send(:"#{name}=", value)
+    #   end
+    # end
   end
 end


### PR DESCRIPTION
The solid cable config is empty in production due to eager-loading of the engine class in lib.
