### PR TITLE
Ensure rss rendering processes article body properly

### DIFF
--- a/app/views/feed/index.xml.builder
+++ b/app/views/feed/index.xml.builder
@@ -5,13 +5,18 @@ xml.rss version: "2.0" do
     xml.description "Tutorials and tips that capture the joy of building web applications with Ruby on Rails"
     xml.link root_url
 
-    ArticlePage.published.take(10).each do |page|
+    ArticlePage.published.take(10).each do |article|
       xml.item do
-        xml.title page.data.title
-        xml.description Markdown::Erb.new(page.body).call
-        xml.pubDate page.published_on.to_formatted_s(:rfc822)
-        xml.link request.base_url + page.request_path
-        xml.guid request.base_url + page.request_path
+        xml.title article.data.title
+        xml.description ::ApplicationController.render(
+          inline: article.body,
+          type: article.page.handler,
+          layout: false,
+          content_type: article.page.mime_type.to_s
+        )
+        xml.pubDate article.published_on.to_formatted_s(:rfc822)
+        xml.link request.base_url + article.request_path
+        xml.guid request.base_url + article.request_path
       end
     end
   end

--- a/spec/requests/feed_spec.rb
+++ b/spec/requests/feed_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Feed", type: :request do
       expect(page).to have_content("Introducing Joy of Rails")
       expect(page).to have_content("/introducing-joy-of-rails")
       expect(page).to have_content("<h2>How it started, How it’s going</h2>")
+      expect(page).to have_content("<pre><code data-code-example-target=\"source\">")
     end
   end
 end


### PR DESCRIPTION
The first attempt to render sitepress markdown-erb articles processed markdown but not ERB. 
#137

This change ensures the article body will go through the full rendering pipeline.
