### PR TITLE
Use hard-coded uuid for atom entry id

### DIFF
--- a/app/content/models/article_page.rb
+++ b/app/content/models/article_page.rb
@@ -15,10 +15,6 @@ class ArticlePage < Sitepress::Model
     all.filter { |article| article.published.blank? }
   end
 
-  def id
-    File.basename(request_path)
-  end
-
   def persisted?
     false
   end

--- a/app/content/pages/articles/introducing-joy-of-rails.html.mdrb
+++ b/app/content/pages/articles/introducing-joy-of-rails.html.mdrb
@@ -6,6 +6,7 @@ summary:
 description: Joy of Rails is a Rails application dedicated to teaching and showing programmers how to use Ruby on Rails and highlighting news, notes, and contributions relevant to the broader Ruby on Rails community
 published: '2024-05-02'
 toc: false
+uuid: 4106248b-ae8f-40a3-9853-48b91d815a71
 tags:
   - Rails
 ---

--- a/app/views/feed/index.atom.builder
+++ b/app/views/feed/index.atom.builder
@@ -5,6 +5,7 @@ atom_feed do |feed|
   @articles.take(50).each do |article|
     feed.entry(
       article,
+      id: "tag:#{request.host},2005:article/#{article.data.uuid!}",
       url: request.base_url + article.request_path
     ) do |entry|
       entry.title(article.title)

--- a/spec/requests/feed_spec.rb
+++ b/spec/requests/feed_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Feed", type: :request do
       validator = W3CValidators::FeedValidator.new
       validator_results = validator.validate_text(response.body) # W3CValidators::Results
 
-      expect(validator_results.is_valid?).to be(true)
+      expect(validator_results.is_valid?).to be(true), "Expected feed to be valid, but got: #{validator_results.errors.map(&:to_s).join(", ")}"
     end
   end
 end


### PR DESCRIPTION
Post records may be associated with Sitepress articles in the future. For now, the hard-coded uuid will act as temporary solution for providing a unique identifier for atom feed entry content. Any modification to the url could make the content appear to be new for feed readers so that may be something to account for in future article changes.

<!-- Describe your changes and link to relevant issues or discussions. Please add motivation and context as needed. -->

## Pull request checklist

- [ ] I have written tests for code I have added or modified.
- [ ] I linted and tested the project with `bin/verify`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
