### PR TITLE
Read app file src with override for repo root

### DIFF
--- a/app/models/examples/app_file.rb
+++ b/app/models/examples/app_file.rb
@@ -37,7 +37,9 @@ module Examples
     end
 
     def read
-      `git show #{@revision}:#{@path}`.strip
+      Dir.chdir(ENV.fetch("REPOSITORY_ROOT", ".")) do
+        `git show #{@revision}:#{@path}`.strip
+      end
     end
     alias_method :content, :read
 

--- a/config/initializers/repository.rb
+++ b/config/initializers/repository.rb
@@ -1,0 +1,15 @@
+RepositoryCheck = Class.new(StandardError)
+message = <<~MSG
+  Repository check failed!
+
+  The application cannot find the git repository at #{ENV.fetch("REPOSITORY_ROOT", ".")}
+  Please set the REPOSITORY_ROOT environment variable to the path of the git repository.
+MSG
+
+unless Rails.env.wasm?
+  Dir.chdir(ENV.fetch("REPOSITORY_ROOT", ".")) do
+    if !system("git rev-parse")
+      raise RepositoryCheck.new(message)
+    end
+  end
+end


### PR DESCRIPTION
In production, the git repository lives in a separate directory from the application code unlike in development or CI. As a quick fix for app file code blocks not rendering, this change allows for a production setting to change directories into the repository root when attempting to run the git command to read the source from the given revision.

<!-- Describe your changes and link to relevant issues or discussions. Please add motivation and context as needed. -->

## Pull request checklist

- [x] I have written tests for code I have added or modified.
- [x] I linted and tested the project with `bin/verify`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
