### PR TITLE
Use ULID for user primary key

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "rails", "~> 7.1", group: [:default, :wasm] # Bundle edge Rails instead: gem
 gem "puma", ">= 5.0" # Use the Puma web server [https://github.com/puma/puma]
 gem "sqlite3", force_ruby_platform: true # Use sqlite3 as the database for Active Record [https://github.com/sparklemotion/sqlite3-ruby]
 gem "activerecord-enhancedsqlite3-adapter" # Enhanced SQLite3 adapter for Active Record [https://github.com/fractaledmind/activerecord-enhancedsqlite3-adapter]
+gem "sqlite-ulid" # A SQLite extension for generating and working with ULIDs [https://github.com/asg017/sqlite-ulid]
 
 gem "solid_cache" # A database-backed ActiveSupport::Cache::Store [https://github.com/rails/solid_cache]
 gem "solid_queue" # A database-backed ActiveJob backend [https://github.com/basecamp/solid_queue]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -457,6 +457,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite-ulid (0.2.1-arm64-darwin)
+    sqlite-ulid (0.2.1-x86_64-linux)
     sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
     standard (1.35.1)
@@ -565,6 +567,7 @@ DEPENDENCIES
   sitepress-rails
   solid_cache
   solid_queue
+  sqlite-ulid
   sqlite3
   standard
   stimulus-rails

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,6 +8,8 @@ default: &default
   adapter: sqlite3
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 3 } %>
   timeout: 5000
+  extensions:
+    - sqlite_ulid
 
 development:
   primary:

--- a/db/migrate/20240605030240_create_users.rb
+++ b/db/migrate/20240605030240_create_users.rb
@@ -1,6 +1,7 @@
 class CreateUsers < ActiveRecord::Migration[7.1]
   def change
-    create_table :users do |t|
+    create_table :users, force: true, id: false do |t|
+      t.primary_key :id, :string, default: -> { "ULID()" }
       t.string :email, null: false
       t.string :password_digest, null: false
 

--- a/db/migrate/20240607120410_create_email_exchanges.rb
+++ b/db/migrate/20240607120410_create_email_exchanges.rb
@@ -2,7 +2,7 @@ class CreateEmailExchanges < ActiveRecord::Migration[7.1]
   def change
     create_table :email_exchanges do |t|
       t.string :email, null: false
-      t.references :user, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true, type: :string
       t.string :status, null: false, default: 0 # pending
 
       t.timestamps

--- a/db/migrate/20240609132723_create_notifications.rb
+++ b/db/migrate/20240609132723_create_notifications.rb
@@ -3,7 +3,7 @@ class CreateNotifications < ActiveRecord::Migration[7.1]
     create_table :notifications do |t|
       t.string :type
       t.references :notification_event, null: false, foreign_key: true
-      t.references :recipient, polymorphic: true, null: false, type: :bigint
+      t.references :recipient, polymorphic: true, null: false, type: :string
       t.datetime :read_at
       t.datetime :seen_at
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,7 +29,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_09_132723) do
 
   create_table "email_exchanges", force: :cascade do |t|
     t.string "email", null: false
-    t.integer "user_id", null: false
+    t.string "user_id", null: false
     t.string "status", default: "0", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -65,7 +65,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_09_132723) do
     t.string "type"
     t.integer "notification_event_id", null: false
     t.string "recipient_type", null: false
-    t.bigint "recipient_id", null: false
+    t.string "recipient_id", null: false
     t.datetime "read_at"
     t.datetime "seen_at"
     t.datetime "created_at", null: false
@@ -74,7 +74,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_09_132723) do
     t.index ["recipient_type", "recipient_id"], name: "index_notifications_on_recipient"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :string, default: -> { "ULID()" }, force: :cascade do |t|
     t.string "email", null: false
     t.string "password_digest", null: false
     t.datetime "created_at", null: false

--- a/spec/views/components/code_block/app_file_spec.rb
+++ b/spec/views/components/code_block/app_file_spec.rb
@@ -33,11 +33,13 @@ RSpec.describe CodeBlock::AppFile, type: :view do
   end
 
   it "renders contents of file by heterogeneous line number collection" do
-    page = render_page(CodeBlock::AppFile.new("config/database.yml", lines: [7..8, 58]))
+    page = render_page(CodeBlock::AppFile.new("config/database.yml", lines: [7..8, 60]))
     expect(page).to have_content(<<~YAML.strip)
       default: &default
         adapter: sqlite3
     YAML
+
+    puts page
 
     expect(page).to have_content("database: storage/production/data.sqlite3")
     expect(page).not_to have_content("database: storage/development/data.sqlite3")


### PR DESCRIPTION
BREAKING CHANGE: This change breaks all sorts of rules by editing migrations. This would not be normally recommended but we’re allowing an exception for this new feature which is still behind a feature flag.

Following advice from https://fractaledmind.github.io/2023/09/22/enhancing-rails-sqlite-ulid-primary-keys/

Before deploy: 

- [x] rollback migrations prior to creating the users table