### PR TITLE
Add code coverage tools

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -92,6 +92,11 @@ jobs:
           RAILS_ENV: test
         run: bin/rspec
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   setup:
     name: Setup
     runs-on: ubuntu-latest
@@ -163,6 +168,11 @@ jobs:
       - name: Run JavaScript unit tests
         run: |
           npm run test -- --watch=false
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   assets:
     name: Assets

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ config/litestream/*.yml
 
 # Ignore rspec failure file
 spec/failures.txt
+
+/coverage

--- a/.simplecov
+++ b/.simplecov
@@ -1,4 +1,12 @@
-SimpleCov.start :rails do
+# frozen_string_literal: true
+
+require "simplecov-tailwindcss"
+
+SimpleCov.formatter = SimpleCov::Formatter::TailwindFormatter
+
+SimpleCov.profiles.define :joyofrails do
+  load_profile "test_frameworks"
+
   add_group "Controllers", "app/controllers"
   add_group "Content", "app/content"
   add_group "Helpers", "app/helpers"
@@ -22,4 +30,8 @@ SimpleCov.start :rails do
 
   add_filter %r{^/lib/assets/}
   add_filter %r{^/lib/rails-wasm/}
+
+  track_files "{app,lib}/**/*.rb"
 end
+
+SimpleCov.start :joyofrails

--- a/.simplecov
+++ b/.simplecov
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
-require "simplecov-tailwindcss"
-
-SimpleCov.formatter = SimpleCov::Formatter::TailwindFormatter
+if ENV["CI"]
+  require "simplecov-cobertura"
+  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+else
+  require "simplecov-tailwindcss"
+  SimpleCov.formatter = SimpleCov::Formatter::TailwindFormatter
+end
 
 SimpleCov.profiles.define :joyofrails do
   load_profile "test_frameworks"

--- a/.simplecov
+++ b/.simplecov
@@ -26,6 +26,9 @@ SimpleCov.profiles.define :joyofrails do
   add_filter %r{^/db/}
   add_filter %r{^/log/}
   add_filter %r{^/storage/}
+  add_filter %r{^/node_modules/}
+  add_filter %r{^/docs/}
+  add_filter %r{^/public/}
   add_filter %r{^/tmp/}
   add_filter %r{^/vendor/}
 

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,25 @@
+SimpleCov.start :rails do
+  add_group "Controllers", "app/controllers"
+  add_group "Content", "app/content"
+  add_group "Helpers", "app/helpers"
+  add_group "Jobs", "app/jobs"
+  add_group "Libraries", "lib"
+  add_group "Mailers", "app/mailers"
+  add_group "Models", "app/models"
+  add_group "Notifiers", "app/notifiers"
+  add_group "Views", "app/views"
+
+  add_filter %r{^/bin/}
+  add_filter %r{^/config/}
+  add_filter %r{^/db/}
+  add_filter %r{^/log/}
+  add_filter %r{^/storage/}
+  add_filter %r{^/tmp/}
+  add_filter %r{^/vendor/}
+
+  add_filter %r{^/app/assets/}
+  add_filter %r{^/app/javascript/}
+
+  add_filter %r{^/lib/assets/}
+  add_filter %r{^/lib/rails-wasm/}
+end

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,8 @@ group :test do
   gem "selenium-webdriver" # Ruby bindings for Selenium [https://www.rubydoc.info/gems/selenium-webdriver/frames]
   gem "cuprite", git: "https://github.com/rubycdp/cuprite"
   gem "simplecov", require: false # Code coverage for Ruby [https://github.com/simplecov-ruby/simplecov]
-  gem "simplecov-tailwindcss", require: false
+  gem "simplecov-tailwindcss", require: false # Alternative HTML formatter for SimpleCov [https://github.com/chiefpansancolt/simplecov-tailwindcss]
+  gem "simplecov-cobertura", require: false # Produces Cobertura formatted XML from SimpleCov. [https://github.com/dashingrocket/simplecov-cobertura]
   gem "webmock", require: false # Library for stubbing HTTP requests [https://github.com/bblimke/webmock]
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :test do
   gem "capybara" # Acceptance test framework for web applications [https://github.com/teamcapybara/capybara]
   gem "selenium-webdriver" # Ruby bindings for Selenium [https://www.rubydoc.info/gems/selenium-webdriver/frames]
   gem "cuprite", git: "https://github.com/rubycdp/cuprite"
+  gem "simplecov", require: false # Code coverage for Ruby [https://github.com/simplecov-ruby/simplecov]
   gem "webmock", require: false # Library for stubbing HTTP requests [https://github.com/bblimke/webmock]
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ group :test do
   gem "selenium-webdriver" # Ruby bindings for Selenium [https://www.rubydoc.info/gems/selenium-webdriver/frames]
   gem "cuprite", git: "https://github.com/rubycdp/cuprite"
   gem "simplecov", require: false # Code coverage for Ruby [https://github.com/simplecov-ruby/simplecov]
+  gem "simplecov-tailwindcss", require: false
   gem "webmock", require: false # Library for stubbing HTTP requests [https://github.com/bblimke/webmock]
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -438,6 +438,8 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
+    simplecov-tailwindcss (2.2.0)
+      simplecov (~> 0.16)
     simplecov_json_formatter (0.1.4)
     sitepress-core (4.0.2)
       mime-types (>= 2.99)
@@ -572,6 +574,7 @@ DEPENDENCIES
   ruby_wasm (~> 2.5)
   selenium-webdriver
   simplecov
+  simplecov-tailwindcss
   sitepress-rails
   solid_cache
   solid_queue

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,7 @@ GEM
       reline (>= 0.3.8)
     device_detector (1.1.2)
     diff-lcs (1.5.1)
+    docile (1.4.0)
     dotenv (3.1.0)
     drb (2.2.1)
     dry-cli (1.0.0)
@@ -432,6 +433,12 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     sexp_processor (4.17.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sitepress-core (4.0.2)
       mime-types (>= 2.99)
     sitepress-rails (4.0.2)
@@ -564,6 +571,7 @@ DEPENDENCIES
   rspec-rails
   ruby_wasm (~> 2.5)
   selenium-webdriver
+  simplecov
   sitepress-rails
   solid_cache
   solid_queue

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -437,6 +437,9 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov-tailwindcss (2.2.0)
       simplecov (~> 0.16)
@@ -574,6 +577,7 @@ DEPENDENCIES
   ruby_wasm (~> 2.5)
   selenium-webdriver
   simplecov
+  simplecov-cobertura
   simplecov-tailwindcss
   sitepress-rails
   solid_cache

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Building a Rails application to help people learn more about building Rails appl
 
   Use a Ruby version manager to install and manage Ruby versions, such as
 
+  - [chruby](https://github.com/postmodern/chruby)
   - [asdf](https://asdf-vm.com/)
   - [rvm](https://rvm.io/)
-  - [chruby](https://github.com/postmodern/chruby)
+  - [rbenv](https://github.com/rbenv/rbenv)
 
   To use YJIT, Rust must first be installed and be found on `PATH`:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # joyofrails.com
 
+[![Build Status](https://github.com/joyofrails/joyofrails.com/workflows/verify.yml/badge.svg)](https://github.com/joyofrails/joyofrails.com/actions)
+[![Deploy Status](https://github.com/joyofrails/joyofrails.com/workflows/deploy.yml/badge.svg)](https://github.com/joyofrails/joyofrails.com/actions)
+[![Code Coverage](https://codecov.io/gh/joyofrails/joyofrails.com/graph/badge.svg?token=PRKDIXWQ7I)](https://codecov.io/gh/joyofrails/joyofrails.com)
+
 A place to learn and celebrate the joy of using Ruby on Rails
 
 https://www.joyofrails.com

--- a/spec/jobs/emails/heartbeat_job_spec.rb
+++ b/spec/jobs/emails/heartbeat_job_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Emails::HeartbeatJob do
+  describe "#perform" do
+    it "sends a heartbeat email to admin users to exercise email provider integration" do
+      admin_user = FactoryBot.create(:admin_user)
+
+      Emails::HeartbeatJob.perform_later
+
+      perform_enqueued_jobs_and_subsequently_enqueued_jobs
+
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+
+      mail = find_mail_to(admin_user.email)
+
+      expect(mail.subject).to eq("It’s alive!")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,11 @@
+# frozen_string_literal: true
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"
+
+require "simplecov"
+
 require_relative "../config/environment"
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?


### PR DESCRIPTION
Adds [SimpleCov](https://github.com/simplecov-ruby/simplecov) and configuration for generating code coverage reports.

[Codecov](https://about.codecov.io/) hosts open source code coverage for free.

simplecov-tailwindcss makes the HTML view look nice:
![Screenshot 2024-06-19 at 7 59 31 AM](https://github.com/joyofrails/joyofrails.com/assets/11673/bd8fb4ab-ea01-47d2-944d-e9b978fa70eb)

simplecov-cobertura generates XML format consumable by Codecov.