### PR TITLE
Thanks page and email admin new user

### DIFF
--- a/app/controllers/concerns/erroring.rb
+++ b/app/controllers/concerns/erroring.rb
@@ -1,5 +1,5 @@
 module Erroring
   def not_found!
-    raise ActionController::RoutingError, "Not Found"
+    raise ActionController::RoutingError, "Route not found #{request.path}"
   end
 end

--- a/app/controllers/users/newsletter_subscriptions_controller.rb
+++ b/app/controllers/users/newsletter_subscriptions_controller.rb
@@ -38,10 +38,10 @@ class Users::NewsletterSubscriptionsController < ApplicationController
       return render Users::NewsletterSubscriptions::NewView.new(newsletter_subscription: @newsletter_subscription), status: :unprocessable_entity
     end
 
-    if @user.needs_confirmation?
+    if @user.previously_new_record?
+      NewUserNotificationJob.perform_later(@user)
+    elsif @user.needs_confirmation?
       EmailConfirmationNotifier.deliver_to(@user)
-    else
-      # TODO: Send already subscribed email
     end
 
     redirect_to users_newsletter_subscription_path(@newsletter_subscription)

--- a/app/controllers/users/newsletter_subscriptions_controller.rb
+++ b/app/controllers/users/newsletter_subscriptions_controller.rb
@@ -26,10 +26,8 @@ class Users::NewsletterSubscriptionsController < ApplicationController
 
   def create
     create_user_params = params.require(:user).permit(:email)
-    @user = User.find_or_initialize_by(email: create_user_params[:email]) do |u|
-      u.subscribing = true
-    end
-
+    @user = User.find_or_initialize_by(email: create_user_params[:email])
+    @user.subscribing = true
     @newsletter_subscription = @user.newsletter_subscription || @user.build_newsletter_subscription
 
     @user.save

--- a/app/controllers/users/newsletter_subscriptions_controller.rb
+++ b/app/controllers/users/newsletter_subscriptions_controller.rb
@@ -39,8 +39,10 @@ class Users::NewsletterSubscriptionsController < ApplicationController
     end
 
     if @user.previously_new_record?
-      NewUserNotificationJob.perform_later(@user)
-    elsif @user.needs_confirmation?
+      NewUserNotifier.deliver_to(AdminUser.all, user: @user)
+    end
+
+    if @user.needs_confirmation?
       EmailConfirmationNotifier.deliver_to(@user)
     end
 

--- a/app/controllers/users/newsletter_subscriptions_controller.rb
+++ b/app/controllers/users/newsletter_subscriptions_controller.rb
@@ -1,5 +1,5 @@
 class Users::NewsletterSubscriptionsController < ApplicationController
-  invisible_captcha only: [:create]
+  # invisible_captcha only: [:create]
 
   before_action :authenticate_user_or_not_found!, only: [:index, :subscribe]
   before_action :authenticate_user!, only: [:subscribe]

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -19,7 +19,7 @@ class Users::RegistrationsController < ApplicationController
       NewUserNotifier.deliver_to(AdminUser.all, user: user)
       EmailConfirmationNotifier.deliver_to(user)
 
-      redirect_to thanks_users_registration_path, notice: "Welcome to Joy of Rails! Please check your email for confirmation instructions"
+      redirect_to users_thank_you_path, notice: "Welcome to Joy of Rails! Please check your email for confirmation instructions"
     else
       render Users::Registrations::NewView.new(user: user), status: :unprocessable_entity
     end
@@ -58,10 +58,6 @@ class Users::RegistrationsController < ApplicationController
     current_user.destroy
     reset_session
     redirect_to root_path, notice: "Your account has been deleted"
-  end
-
-  def thanks
-    render Users::Dashboard::IndexView.new
   end
 
   private

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -17,7 +17,7 @@ class Users::RegistrationsController < ApplicationController
     @user = User.new(create_user_params)
     if @user.save
       EmailConfirmationNotifier.deliver_to(@user)
-      redirect_to root_path, notice: "Welcome to Joy of Rails! Please check your email for confirmation instructions"
+      redirect_to thanks_users_registration_path, notice: "Welcome to Joy of Rails! Please check your email for confirmation instructions"
     else
       render Users::Registrations::NewView.new(user: @user), status: :unprocessable_entity
     end
@@ -56,6 +56,10 @@ class Users::RegistrationsController < ApplicationController
     current_user.destroy
     reset_session
     redirect_to root_path, notice: "Your account has been deleted"
+  end
+
+  def thanks
+    render Users::Dashboard::IndexView.new
   end
 
   private

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -16,7 +16,7 @@ class Users::RegistrationsController < ApplicationController
     create_user_params = params.require(:user).permit(:email, :password, :password_confirmation)
     @user = User.new(create_user_params)
     if @user.save
-      EmailConfirmationNotifier.deliver_to(@user)
+      NewUserNotificationJob.perform_later(@user)
       redirect_to thanks_users_registration_path, notice: "Welcome to Joy of Rails! Please check your email for confirmation instructions"
     else
       render Users::Registrations::NewView.new(user: @user), status: :unprocessable_entity

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -8,44 +8,46 @@ class Users::RegistrationsController < ApplicationController
   before_action :authenticate_user!, only: [:edit, :update, :destroy]
 
   def new
-    @user = User.new
-    render Users::Registrations::NewView.new(user: @user)
+    user = User.new
+    render Users::Registrations::NewView.new(user: user)
   end
 
   def create
     create_user_params = params.require(:user).permit(:email, :password, :password_confirmation)
-    @user = User.new(create_user_params)
-    if @user.save
-      NewUserNotificationJob.perform_later(@user)
+    user = User.new(create_user_params)
+    if user.save
+      NewUserNotifier.deliver_to(AdminUser.all, user: user)
+      EmailConfirmationNotifier.deliver_to(user)
+
       redirect_to thanks_users_registration_path, notice: "Welcome to Joy of Rails! Please check your email for confirmation instructions"
     else
-      render Users::Registrations::NewView.new(user: @user), status: :unprocessable_entity
+      render Users::Registrations::NewView.new(user: user), status: :unprocessable_entity
     end
   end
 
   def edit
-    @user = current_user
-    @user.email_exchanges.build
+    user = current_user
+    user.email_exchanges.build
 
-    render Users::Registrations::EditView.new(user: @user)
+    render Users::Registrations::EditView.new(user: user)
   end
 
   def update
     update_user_params = params.require(:user).permit(:password_challenge, :password, :password_confirmation, email_exchanges_attributes: [:email])
 
-    @user = current_user
+    user = current_user
 
-    if !@user.authenticate(params[:user][:password_challenge])
+    if !user.authenticate(params[:user][:password_challenge])
       flash.now[:error] = "Incorrect password"
-      return render Users::Registrations::EditView.new(user: @user), status: :unprocessable_entity
+      return render Users::Registrations::EditView.new(user: user), status: :unprocessable_entity
     end
 
-    if !@user.update(update_user_params)
-      return render Users::Registrations::EditView.new(user: @user), status: :unprocessable_entity
+    if !user.update(update_user_params)
+      return render Users::Registrations::EditView.new(user: user), status: :unprocessable_entity
     end
 
     if update_user_params[:email_exchanges_attributes].present?
-      EmailConfirmationNotifier.deliver_to(@user)
+      EmailConfirmationNotifier.deliver_to(user)
       redirect_to users_dashboard_path, notice: "Check your email for confirmation instructions"
     else
       redirect_to users_dashboard_path, notice: "Account updated"

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -37,12 +37,13 @@ class Users::RegistrationsController < ApplicationController
 
     user = current_user
 
-    if !user.authenticate(params[:user][:password_challenge])
+    if user.password_digest_was.present? && !user.authenticate(params[:user][:password_challenge])
       flash.now[:error] = "Incorrect password"
       return render Users::Registrations::EditView.new(user: user), status: :unprocessable_entity
     end
 
     if !user.update(update_user_params)
+      flash.now[:error] = user.errors.full_messages.to_sentence
       return render Users::Registrations::EditView.new(user: user), status: :unprocessable_entity
     end
 

--- a/app/controllers/users/thank_yous_controller.rb
+++ b/app/controllers/users/thank_yous_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Users::ThankYousController < ApplicationController
+  def show
+    render Users::ThankYous::ShowView.new
+  end
+end

--- a/app/javascript/css/utilities/tailwind.css
+++ b/app/javascript/css/utilities/tailwind.css
@@ -937,3 +937,15 @@ focus\:ring-0:focus {
 .max-w-sm {
   max-width: 24rem;
 }
+
+.list-disc {
+  list-style-type: disc;
+}
+
+.list-inside {
+  list-style-position: inside;
+}
+
+.list-outside {
+  list-style-position: outside;
+}

--- a/app/jobs/new_user_notification_job.rb
+++ b/app/jobs/new_user_notification_job.rb
@@ -1,0 +1,9 @@
+class NewUserNotificationJob < ApplicationJob
+  queue_as :default
+
+  def perform(user)
+    # Do something later
+    NewUserNotifier.deliver_to(AdminUser.all, user: user)
+    EmailConfirmationNotifier.deliver_to(user)
+  end
+end

--- a/app/jobs/new_user_notification_job.rb
+++ b/app/jobs/new_user_notification_job.rb
@@ -1,9 +1,0 @@
-class NewUserNotificationJob < ApplicationJob
-  queue_as :default
-
-  def perform(user)
-    # Do something later
-    NewUserNotifier.deliver_to(AdminUser.all, user: user)
-    EmailConfirmationNotifier.deliver_to(user)
-  end
-end

--- a/app/mailers/emails/admin_user_mailer.rb
+++ b/app/mailers/emails/admin_user_mailer.rb
@@ -1,0 +1,8 @@
+class Emails::AdminUserMailer < ApplicationMailer
+  def new_user(admin_user:, user:)
+    @admin_user = admin_user
+    @user = user
+
+    mail to: @admin_user.email, subject: "New Joy of Rails User"
+  end
+end

--- a/app/notifiers/new_user_notifier.rb
+++ b/app/notifiers/new_user_notifier.rb
@@ -1,0 +1,12 @@
+class NewUserNotifier < NotificationEvent
+  def self.deliver_to(admin_user, user:, **)
+    new(params: {user_id: user.id}).deliver(admin_user, **)
+  end
+
+  def deliver_notification(notification)
+    admin_user = notification.recipient
+    user = User.find(params[:user_id])
+
+    Emails::AdminUserMailer.new_user(admin_user: admin_user, user: user).deliver_later
+  end
+end

--- a/app/views/emails/admin_user_mailer/new_user.html.erb
+++ b/app/views/emails/admin_user_mailer/new_user.html.erb
@@ -1,0 +1,5 @@
+<h2>New User</h2>
+
+<%= mail_to @user.confirmable_email %> just registered for Joy of Rails!
+
+Woo hoo!

--- a/app/views/emails/admin_user_mailer/new_user.text.erb
+++ b/app/views/emails/admin_user_mailer/new_user.text.erb
@@ -1,0 +1,5 @@
+New User
+
+<%= @user.confirmable_email %> just registered for Joy of Rails!
+
+Woo hoo!

--- a/app/views/users/newsletter_subscriptions/show_view.rb
+++ b/app/views/users/newsletter_subscriptions/show_view.rb
@@ -27,6 +27,15 @@ class Users::NewsletterSubscriptions::ShowView < ApplicationView
             render Users::NewsletterSubscriptions::SubscribeButton.new
           end
         end
+
+        script(type: "text/javascript") do
+          unsafe_raw <<~JS
+            if (window.plausible) {
+              window.plausible("Newsletter signup");
+              console.log("Newsletter signup");
+            }
+          JS
+        end
       end
     end
   end

--- a/app/views/users/newsletter_subscriptions/show_view.rb
+++ b/app/views/users/newsletter_subscriptions/show_view.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Users::NewsletterSubscriptions::ShowView < ApplicationView
+  include Phlex::Rails::Helpers::LinkTo
   include Phlex::Rails::Helpers::TurboFrameTag
 
   def initialize(newsletter_subscription:, show_unsubscribe: false)
@@ -31,7 +32,9 @@ class Users::NewsletterSubscriptions::ShowView < ApplicationView
   end
 
   def subscribed_message
-    plain "You are subscribed to the Joy of Rails newsletter!"
+    link_to("Thank you", users_thank_you_path, class: "font-bold", data: {turbo_frame: "_top"})
+    whitespace
+    plain "for subscribing to the Joy of Rails newsletter!"
     if @newsletter_subscription.subscriber.needs_confirmation?
       whitespace
       plain "Please check your email for a confirmation link."

--- a/app/views/users/registrations/thanks_view.rb
+++ b/app/views/users/registrations/thanks_view.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Users::Dashboard::IndexView < ApplicationView
+class Users::Registration::ThanksView < ApplicationView
   include Phlex::Rails::Helpers::LinkTo
 
   def view_template

--- a/app/views/users/thank_yous/show_view.rb
+++ b/app/views/users/thank_yous/show_view.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Users::Registration::ThanksView < ApplicationView
+class Users::ThankYous::ShowView < ApplicationView
   include Phlex::Rails::Helpers::LinkTo
 
   def view_template
@@ -27,6 +27,10 @@ class Users::Registration::ThanksView < ApplicationView
             strong { link_to("articles", "/articles") }
             whitespace
             plain "I’ve written on Ruby, Rails, and Hotwire."
+            if ArticlePage.published.length < 5
+              whitespace
+              plain "I’m working on adding some new content, so check back soon!"
+            end
           end
           li do
             plain "If you’re interested in learning how this app is built or even contributing to it, check out the"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,11 @@ Rails.application.routes.draw do
 
   namespace :users do
     resource :header_navigation, only: [:show]
-    resource :registration, only: [:new, :create, :edit, :update, :destroy]
+    resource :registration, only: [:new, :create, :edit, :update, :destroy] do
+      collection do
+        get :thanks
+      end
+    end
     resources :confirmations, only: [:new, :create, :edit, :update], param: :token
     resources :passwords, only: [:new, :create, :edit, :update], param: :token
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,12 +32,9 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", :as => :rails_health_check
 
   namespace :users do
+    resource :thank_you, only: [:show]
     resource :header_navigation, only: [:show]
-    resource :registration, only: [:new, :create, :edit, :update, :destroy] do
-      collection do
-        get :thanks
-      end
-    end
+    resource :registration, only: [:new, :create, :edit, :update, :destroy]
     resources :confirmations, only: [:new, :create, :edit, :update], param: :token
     resources :passwords, only: [:new, :create, :edit, :update], param: :token
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -22,6 +22,11 @@ FactoryBot.define do
       password_confirmation { nil }
     end
 
+    trait :subscriber do
+      subscribing
+      newsletter_subscription
+    end
+
     trait :subscribed do
       newsletter_subscription
     end

--- a/spec/mailers/emails/admin_user_mailer_spec.rb
+++ b/spec/mailers/emails/admin_user_mailer_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Emails::AdminUserMailer, type: :mailer do
+  describe "new_user" do
+    let(:admin_user) { instance_double(AdminUser, email: "admin@example.com") }
+    let(:user) { instance_double(User, confirmable_email: "user@example.com") }
+    let(:mail) { Emails::AdminUserMailer.new_user(admin_user:, user:) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("New Joy of Rails User")
+      expect(mail.to).to eq(["admin@example.com"])
+      expect(mail.from).to eq(["hello@joyofrails.com"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("user@example.com")
+      expect(mail.body.encoded).to match("just registered for Joy of Rails!")
+    end
+  end
+end

--- a/spec/mailers/previews/emails/admin_user_mailer_preview.rb
+++ b/spec/mailers/previews/emails/admin_user_mailer_preview.rb
@@ -1,0 +1,6 @@
+# Preview all emails at http://localhost:3000/rails/mailers/admin_user
+class Emails::AdminUserMailerPreview < ActionMailer::Preview
+  def new_user
+    Emails::AdminUserMailer.new_user(admin_user: FactoryBot.build(:admin_user), user: FactoryBot.build(:user))
+  end
+end

--- a/spec/requests/users/newsletter_subscriptions_spec.rb
+++ b/spec/requests/users/newsletter_subscriptions_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "Newsletter Subscriptions", type: :request do
     end
 
     it "disallows for a subscribing with an already subscribed email" do
-      user = FactoryBot.create(:user, :subscribed)
+      user = FactoryBot.create(:user, :subscriber)
 
       expect {
         post users_newsletter_subscriptions_path,

--- a/spec/requests/users/newsletter_subscriptions_spec.rb
+++ b/spec/requests/users/newsletter_subscriptions_spec.rb
@@ -80,6 +80,20 @@ RSpec.describe "Newsletter Subscriptions", type: :request do
       expect(mail.subject).to eq "Confirm your email address"
     end
 
+    it "notifies admin for new user" do
+      email = FactoryBot.generate(:email)
+      admin = FactoryBot.create(:admin_user)
+
+      post users_newsletter_subscriptions_path,
+        params: {user: {email: email, password: "password", password_confirmation: "password"}}
+
+      perform_enqueued_jobs_and_subsequently_enqueued_jobs
+
+      mail = find_mail_to(admin.email)
+
+      expect(mail.subject).to eq "New Joy of Rails User"
+    end
+
     it "disallows for a subscribing with an already subscribed email" do
       user = FactoryBot.create(:user, :subscribed)
 
@@ -94,7 +108,7 @@ RSpec.describe "Newsletter Subscriptions", type: :request do
       # assert "already subscribed" email sent
     end
 
-    it "succeeds for a user with existing accout who is not currently subscribed email" do
+    it "succeeds for a user with existing account who is not currently subscribed email" do
       user = FactoryBot.create(:user, :unsubscribed)
 
       expect {
@@ -105,6 +119,28 @@ RSpec.describe "Newsletter Subscriptions", type: :request do
       expect(response).to redirect_to(users_newsletter_subscription_path(User.last.newsletter_subscription))
 
       expect(user.reload.newsletter_subscription).to be_present
+    end
+
+    it "sends confirmation for an unconfirmed user with existing account who is not currently subscribed email" do
+      user = FactoryBot.create(:user, :unsubscribed, :unconfirmed)
+      admin = FactoryBot.create(:admin_user)
+
+      expect {
+        post users_newsletter_subscriptions_path,
+          params: {user: {email: user.email}}
+      }.to change(NewsletterSubscription, :count).by(1)
+
+      expect(response).to redirect_to(users_newsletter_subscription_path(User.last.newsletter_subscription))
+
+      expect(user.reload.newsletter_subscription).to be_present
+
+      perform_enqueued_jobs_and_subsequently_enqueued_jobs
+
+      mail = find_mail_to(user.email)
+
+      expect(mail.subject).to eq "Confirm your email address"
+
+      expect(find_mail_to(admin.email)).to be_nil
     end
 
     it "disallows a user to subscribe with an invalid email" do

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Registrations", type: :request do
     Flipper[:user_registration].enable
   end
 
-  describe "GET create" do
+  describe "GET new" do
     it "succeeds for signed out user" do
       get new_users_registration_path
 
@@ -31,7 +31,7 @@ RSpec.describe "Registrations", type: :request do
           params: {user: {email: email, password: "password", password_confirmation: "password"}}
       }.to change(User, :count).by(1)
 
-      expect(response).to redirect_to(root_path)
+      expect(response).to redirect_to(thanks_users_registration_path)
       expect(flash[:notice]).to eq("Welcome to Joy of Rails! Please check your email for confirmation instructions")
 
       perform_enqueued_jobs_and_subsequently_enqueued_jobs

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Registrations", type: :request do
           params: {user: {email: email, password: "password", password_confirmation: "password"}}
       }.to change(User, :count).by(1)
 
-      expect(response).to redirect_to(thanks_users_registration_path)
+      expect(response).to redirect_to(users_thank_you_path)
       expect(flash[:notice]).to eq("Welcome to Joy of Rails! Please check your email for confirmation instructions")
 
       perform_enqueued_jobs_and_subsequently_enqueued_jobs

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -43,6 +43,20 @@ RSpec.describe "Registrations", type: :request do
       expect(mail.subject).to eq "Confirm your email address"
     end
 
+    it "notifies admin" do
+      email = FactoryBot.generate(:email)
+      admin = FactoryBot.create(:admin_user)
+
+      post users_registration_path,
+        params: {user: {email: email, password: "password", password_confirmation: "password"}}
+
+      perform_enqueued_jobs_and_subsequently_enqueued_jobs
+
+      mail = find_mail_to(admin.email)
+
+      expect(mail.subject).to eq "New Joy of Rails User"
+    end
+
     it "disallows a user to subscribe with existing email" do
       user = FactoryBot.create(:user)
 

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -173,5 +173,27 @@ RSpec.describe "Registrations", type: :request do
       expect(flash.now[:error]).to eq("Incorrect password")
       expect(response).to have_http_status(:unprocessable_entity)
     end
+
+    it "allows for subscriber setting password first time" do
+      user = FactoryBot.create(:user, :confirmed, :subscriber)
+      login_user(user)
+
+      put users_registration_path,
+        params: {user: {password: "password", password_confirmation: "password"}}
+
+      expect(response).to redirect_to(users_dashboard_path)
+      expect(flash[:notice]).to eq("Account updated")
+    end
+
+    it "disallows for subscriber setting password first time without password confirmation" do
+      user = FactoryBot.create(:user, :confirmed, :subscriber)
+      login_user(user)
+
+      put users_registration_path,
+        params: {user: {password: "password", password_confirmation: "wrongpassword"}}
+
+      expect(flash.now[:error]).to eq("Password confirmation doesn't match Password")
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
   end
 end

--- a/spec/support/mail_helpers.rb
+++ b/spec/support/mail_helpers.rb
@@ -17,8 +17,9 @@ module MailHelpers
   end
 
   def perform_enqueued_jobs_and_subsequently_enqueued_jobs
-    perform_enqueued_jobs # Process event job
-    perform_enqueued_jobs # Process mailer job
+    3.times do
+      perform_enqueued_jobs
+    end
   end
 
   private

--- a/spec/system/users/newsletter_subscriptions_spec.rb
+++ b/spec/system/users/newsletter_subscriptions_spec.rb
@@ -12,11 +12,16 @@ RSpec.describe "Newsletter subscriptions", type: :system do
     fill_in "user[email]", with: "hello@example.com"
     click_button "Subscribe"
 
-    expect(page).to have_content("You are subscribed to the Joy of Rails newsletter! Please check your email for a confirmation link.")
+    expect(page).to have_content("Thank you for subscribing to the Joy of Rails newsletter! Please check your email for a confirmation link.")
 
     user = User.last
     expect(user.email).to eq("hello@example.com")
     expect(user.subscribed_to_newsletter?).to eq(true)
+
+    click_link "Thank you"
+
+    expect(page).to have_content("Welcome to Joy of Rails!")
+    expect(page).to have_content("Thank you for signing up")
   end
 
   it "allows a logged-in user to subscribe to the newsletter" do
@@ -28,7 +33,7 @@ RSpec.describe "Newsletter subscriptions", type: :system do
 
     click_button "Subscribe"
 
-    expect(page).to have_content("You are subscribed to the Joy of Rails newsletter! Please check your email for a confirmation link.")
+    expect(page).to have_content("Thank you for subscribing to the Joy of Rails newsletter! Please check your email for a confirmation link.")
 
     expect(user.reload.subscribed_to_newsletter?).to be_truthy
 


### PR DESCRIPTION
This change directs new subscribers to a thank you page after registration. Subscribers can get to this page via link in the successful subscription method.

Disables invisible captcha while I can troubleshoot false positives. I may need some other way of dealing with spam emails in the mean time.

Admins will receive an email notification for new subscribers.

Addresses some bugs in the subscriber/registration UX.