### PR TITLE
Add welcome email for new subscribers

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -53,6 +53,8 @@ class Users::ConfirmationsController < ApplicationController
     if @user.confirm!
       warden.set_user(@user, scope: :user)
 
+      WelcomeNotifier.deliver_to(@user)
+
       redirect_to users_dashboard_path, notice: "Thank you for confirming your email address"
     else
       redirect_to new_users_confirmation_path, alert: "Something went wrong"

--- a/app/jobs/notifications/event_job.rb
+++ b/app/jobs/notifications/event_job.rb
@@ -4,7 +4,10 @@ class Notifications::EventJob < ApplicationJob
   def perform(event)
     # Enqueue individual deliveries
     event.notifications.each do |notification|
-      event.deliver_notification(notification)
+      notification.transaction do
+        event.deliver_notification(notification)
+        notification.touch(:processed_at)
+      end
     end
   end
 end

--- a/app/lib/warden_extensions/setup.rb
+++ b/app/lib/warden_extensions/setup.rb
@@ -22,6 +22,7 @@ module WardenExtensions
         case auth.winning_strategy&.key
         when :magic_session
           user.confirm!
+          WelcomeNotifier.deliver_to(user)
         when :password
           # no op
         else # nil, as with test helpers

--- a/app/mailers/emails/user_mailer.rb
+++ b/app/mailers/emails/user_mailer.rb
@@ -19,4 +19,10 @@ class Emails::UserMailer < ApplicationMailer
 
     mail to: @user.email, subject: "Reset your password"
   end
+
+  def welcome(user)
+    @user = user
+
+    mail to: @user.email, subject: "Welcome to Joy of Rails!"
+  end
 end

--- a/app/mailers/emails/user_mailer.rb
+++ b/app/mailers/emails/user_mailer.rb
@@ -20,8 +20,9 @@ class Emails::UserMailer < ApplicationMailer
     mail to: @user.email, subject: "Reset your password"
   end
 
-  def welcome(user)
+  def welcome(user, unsubscribe_token = :no_token)
     @user = user
+    @unsubscribe_token = unsubscribe_token
 
     mail to: @user.email, subject: "Welcome to Joy of Rails!"
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -5,4 +5,6 @@ class Notification < ApplicationRecord
   scope :newest_first, -> { order(created_at: :desc) }
 
   delegate :params, :record, to: :event
+
+  scope :processed, -> { where.not(processed_at: nil) }
 end

--- a/app/models/notification_event.rb
+++ b/app/models/notification_event.rb
@@ -29,16 +29,22 @@ class NotificationEvent < ApplicationRecord
     notifier.const_set :Notification, Class.new(Notification)
   end
 
+  def deliver_to?(recipient)
+    true
+  end
+
   # CommentNotifier.deliver(User.all)
   # CommentNotifier.deliver(User.all, priority: 10)
   # CommentNotifier.deliver(User.all, queue: :low_priority)
   # CommentNotifier.deliver(User.all, wait: 5.minutes)
   # CommentNotifier.deliver(User.all, wait_until: 1.hour.from_now)
-  def deliver(recipients = nil, enqueue_job: true, **options)
+  def deliver(given_recipients = nil, enqueue_job: true, **options)
     validate!
 
+    recipients = Array.wrap(given_recipients)
+
     transaction do
-      recipients_attributes = Array.wrap(recipients).map do |recipient|
+      recipients_attributes = recipients.map do |recipient|
         recipient_attributes_for(recipient)
       end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
 
   has_one :newsletter_subscription, as: :subscriber, dependent: :destroy
 
+  scope :recently_confirmed, -> { where("confirmed_at > ?", 2.weeks.ago) }
+
   accepts_nested_attributes_for :email_exchanges, limit: 1
 
   validates :email, presence: true, uniqueness: true, format: {with: URI::MailTo::EMAIL_REGEXP}

--- a/app/notifiers/welcome_notifier.rb
+++ b/app/notifiers/welcome_notifier.rb
@@ -5,6 +5,7 @@ class WelcomeNotifier < NotificationEvent
 
   def deliver_notification(notification)
     user = notification.recipient
+    unsubscribe_token = user&.newsletter_subscription&.generate_token_for(:unsubscribe) || :no_token
 
     if !deliver_to?(user)
       Rails.logger.info "#[#{self.class}] Skipping delivery for: #{user.class.name}##{user.id}"
@@ -12,7 +13,7 @@ class WelcomeNotifier < NotificationEvent
       return false
     end
 
-    Emails::UserMailer.welcome(user).deliver_later
+    Emails::UserMailer.welcome(user, unsubscribe_token).deliver_later
   end
 
   def deliver_to?(recipient)

--- a/app/notifiers/welcome_notifier.rb
+++ b/app/notifiers/welcome_notifier.rb
@@ -1,0 +1,11 @@
+class WelcomeNotifier < NotificationEvent
+  def self.deliver_to(user, **)
+    new(params: {user: user}).deliver(user, **)
+  end
+
+  def deliver_notification(notification)
+    user = notification.recipient
+
+    Emails::UserMailer.welcome(user).deliver_later
+  end
+end

--- a/app/notifiers/welcome_notifier.rb
+++ b/app/notifiers/welcome_notifier.rb
@@ -16,6 +16,6 @@ class WelcomeNotifier < NotificationEvent
   end
 
   def deliver_to?(recipient)
-    Notification.joins(:notification_event).where(recipient: recipient, notification_event: {type: self.class.name}).count < 2
+    Notification.processed.joins(:notification_event).where(recipient: recipient, notification_event: {type: self.class.name}).count < 1
   end
 end

--- a/app/views/emails/magic_session_mailer/no_account_found.text.erb
+++ b/app/views/emails/magic_session_mailer/no_account_found.text.erb
@@ -1,4 +1,4 @@
-Is this the right email?
+# Is this the right email?
 
 It looks like there isn’t an account on test tied to this email address.
 

--- a/app/views/emails/magic_session_mailer/sign_in_link.text.erb
+++ b/app/views/emails/magic_session_mailer/sign_in_link.text.erb
@@ -1,3 +1,3 @@
-Sign in to Joy of Rails
+# Sign in to Joy of Rails
 
 Follow this link to sign in: <%= users_magic_session_token_url(@magic_session_token) %>

--- a/app/views/emails/user_mailer/confirmation.html.erb
+++ b/app/views/emails/user_mailer/confirmation.html.erb
@@ -1,4 +1,4 @@
-<h1>Welcome to Joy of Rails!</h1>
+<h1>Complete your Joy of Rails registration</h1>
 
 <p>
 <%= link_to "Confirm your email address", edit_users_confirmation_url(@confirmation_token) %>.

--- a/app/views/emails/user_mailer/confirmation.text.erb
+++ b/app/views/emails/user_mailer/confirmation.text.erb
@@ -1,3 +1,3 @@
-Welcome to Joy of Rails!
+# Complete your Joy of Rails registration
 
 Follow this link to confirm your email address: <%= edit_users_confirmation_url(@confirmation_token) %>

--- a/app/views/emails/user_mailer/password_reset.text.erb
+++ b/app/views/emails/user_mailer/password_reset.text.erb
@@ -1,3 +1,3 @@
-Password reset for Joy of Rails
+# Password reset for Joy of Rails
 
 Follow this link to reset your password: <%= edit_users_password_url(@password_reset_token) %>

--- a/app/views/emails/user_mailer/welcome.html.erb
+++ b/app/views/emails/user_mailer/welcome.html.erb
@@ -1,0 +1,13 @@
+<p>Thank you for signing up for the Joy of Rails newsletter! I am humbled to have you here :)</p>
+
+<p>As you might have guessed, things are just getting underway at Joy of Rails. You’re one of the first to join and I’m grateful for that. I’m excited to see where this journey takes us. Tell your friends and colleagues and spread the Joy of Rails. The more the merrier!</p>
+
+<p>Now that you’ve joined, you can expect occasional email updates from me. I’ll do my best to send you interesting and engaging Ruby on Rails content that’s worth your attention and time. Maybe every, now and then, something to put a smile on your face.</p>
+
+<p>If you’re into RSS, you may want to subscribe to the <%= link_to "Joy of Rails feed", feed_index_url %>.</p>
+
+<p>You can also <%= link_to "unsubscribe", unsubscribe_users_newsletter_subscriptions_url %> at any time. That’s ok too!</p>
+
+<p>If you have any questions, feedback, or just want to say hi, please don’t hesitate to reach out. I’d love to hear from you.</p>
+
+<p>- Ross</p>

--- a/app/views/emails/user_mailer/welcome.html.erb
+++ b/app/views/emails/user_mailer/welcome.html.erb
@@ -1,6 +1,6 @@
 <p>Thank you for signing up for the Joy of Rails newsletter! I am humbled to have you here :)</p>
 
-<p>As you might have guessed, things are just getting underway at Joy of Rails. You’re one of the first to join and I’m grateful for that. I’m excited to see where this journey takes us. Tell your friends and colleagues and spread the Joy of Rails. The more the merrier!</p>
+<p>As you might have guessed, things are just getting underway at Joy of Rails. You’re one of the first to join and I’m grateful for that. I’m excited to see where this journey takes us. And please tell your friends and colleagues about Joy of Rails. The more the merrier!</p>
 
 <p>Now that you’ve joined, you can expect occasional email updates from me. I’ll do my best to send you interesting and engaging Ruby on Rails content that’s worth your attention and time. Maybe every, now and then, something to put a smile on your face.</p>
 

--- a/app/views/emails/user_mailer/welcome.html.erb
+++ b/app/views/emails/user_mailer/welcome.html.erb
@@ -6,7 +6,9 @@
 
 <p>If you’re into RSS, you may want to subscribe to the <%= link_to "Joy of Rails feed", feed_index_url %>.</p>
 
-<p>You can also <%= link_to "unsubscribe", unsubscribe_users_newsletter_subscriptions_url %> at any time. That’s ok too!</p>
+<% unless @unsubscribe_token == :no_token %>
+<p>You can also <%= link_to "unsubscribe", unsubscribe_users_newsletter_subscription_url(@unsubscribe_token) %> at any time. That’s ok too!</p>
+<% end %>
 
 <p>If you have any questions, feedback, or just want to say hi, please don’t hesitate to reach out. I’d love to hear from you.</p>
 

--- a/app/views/emails/user_mailer/welcome.text.erb
+++ b/app/views/emails/user_mailer/welcome.text.erb
@@ -1,6 +1,6 @@
 Thank you for signing up for the Joy of Rails newsletter! I am humbled to have you here :)
 
-As you might have guessed, things are just getting underway at Joy of Rails. You’re one of the first to join and I’m grateful for that. I’m excited to see where this journey takes us. Tell your friends and colleagues about Joy of Rails. The more the merrier!
+As you might have guessed, things are just getting underway at Joy of Rails. You’re one of the first to join and I’m grateful for that. I’m excited to see where this journey takes us. And please tell your friends and colleagues about Joy of Rails. The more the merrier!
 
 Now that you’ve joined, you can expect occasional email updates from me. I’m going to do my best to send you interesting and engaging Ruby on Rails content that’s worth your attention and time. Maybe every, now and then, something to put a smile on your face.
 

--- a/app/views/emails/user_mailer/welcome.text.erb
+++ b/app/views/emails/user_mailer/welcome.text.erb
@@ -1,0 +1,13 @@
+Thank you for signing up for the Joy of Rails newsletter! I am humbled to have you here :)
+
+As you might have guessed, things are just getting underway at Joy of Rails. You’re one of the first to join and I’m grateful for that. I’m excited to see where this journey takes us. Tell your friends and colleagues about Joy of Rails. The more the merrier!
+
+Now that you’ve joined, you can expect occasional email updates from me. I’m going to do my best to send you interesting and engaging Ruby on Rails content that’s worth your attention and time. Maybe every, now and then, something to put a smile on your face.
+
+If you’re into RSS, you may want to subscribe to the Joy of Rails feed: <%= feed_index_url %>.
+
+You can also unsubscribe at any time: <%= unsubscribe_users_newsletter_subscriptions_url %>. That’s ok too!
+
+If you have any questions, feedback, or just want to say hi, please don’t hesitate to reach out. I’d love to hear from you.
+
+- Ross

--- a/app/views/emails/user_mailer/welcome.text.erb
+++ b/app/views/emails/user_mailer/welcome.text.erb
@@ -6,7 +6,9 @@ Now that you’ve joined, you can expect occasional email updates from me. I’m
 
 If you’re into RSS, you may want to subscribe to the Joy of Rails feed: <%= feed_index_url %>.
 
-You can also unsubscribe at any time: <%= unsubscribe_users_newsletter_subscriptions_url %>. That’s ok too!
+<% unless @unsubscribe_token == :no_token %>
+You can also unsubscribe at any time: <%= unsubscribe_users_newsletter_subscription_url(@unsubscribe_token) %>. That’s ok too!
+<% end %>
 
 If you have any questions, feedback, or just want to say hi, please don’t hesitate to reach out. I’d love to hear from you.
 

--- a/db/migrate/20240720123745_add_processed_at_to_notifications.rb
+++ b/db/migrate/20240720123745_add_processed_at_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddProcessedAtToNotifications < ActiveRecord::Migration[7.1]
+  def change
+    add_column :notifications, :processed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_03_114157) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_20_123745) do
   create_table "_litestream_lock", id: false, force: :cascade do |t|
     t.integer "id"
   end
@@ -96,6 +96,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_03_114157) do
     t.datetime "seen_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "processed_at"
     t.index ["notification_event_id"], name: "index_notifications_on_notification_event_id"
     t.index ["recipient_type", "recipient_id"], name: "index_notifications_on_recipient"
   end

--- a/lib/tasks/emails/welcome.rake
+++ b/lib/tasks/emails/welcome.rake
@@ -1,0 +1,7 @@
+namespace :emails do
+  task welcome: :environment do
+    User.recently_confirmed.find_each do |user|
+      WelcomeNotifier.deliver_to(user)
+    end
+  end
+end

--- a/spec/mailers/emails/user_mailer_spec.rb
+++ b/spec/mailers/emails/user_mailer_spec.rb
@@ -30,4 +30,19 @@ RSpec.describe Emails::UserMailer, type: :mailer do
       expect(mail.body.encoded).to match("reset your password")
     end
   end
+
+  describe "welcome" do
+    let(:user) { instance_double(User, email: "to@example.com") }
+    let(:mail) { Emails::UserMailer.welcome(user) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Welcome to Joy of Rails!")
+      expect(mail.to).to eq(["to@example.com"])
+      expect(mail.from).to eq(["hello@joyofrails.com"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("Thank you for signing up")
+    end
+  end
 end

--- a/spec/mailers/previews/emails/user_mailer_preview.rb
+++ b/spec/mailers/previews/emails/user_mailer_preview.rb
@@ -8,4 +8,8 @@ class Emails::UserMailerPreview < ActionMailer::Preview
   def password_reset
     Emails::UserMailer.password_reset(FactoryBot.build(:user), "password_reset_token")
   end
+
+  def welcome
+    Emails::UserMailer.welcome(FactoryBot.build(:user))
+  end
 end

--- a/spec/mailers/previews/emails/user_mailer_preview.rb
+++ b/spec/mailers/previews/emails/user_mailer_preview.rb
@@ -10,6 +10,6 @@ class Emails::UserMailerPreview < ActionMailer::Preview
   end
 
   def welcome
-    Emails::UserMailer.welcome(FactoryBot.build(:user))
+    Emails::UserMailer.welcome(FactoryBot.build(:user), "unsubscribe_token")
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -34,4 +34,14 @@ RSpec.describe User, type: :model do
       }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Email has already been taken")
     end
   end
+
+  describe ".recently_confirmed" do
+    it "returns recently (within 2 weeks) confirmed users" do
+      FactoryBot.create(:user, confirmed_at: 1.month.ago)
+      recently_confirmed_user = FactoryBot.create(:user, confirmed_at: 1.week.ago)
+      FactoryBot.create(:user, :unconfirmed)
+
+      expect(User.recently_confirmed).to eq([recently_confirmed_user])
+    end
+  end
 end

--- a/spec/notifiers/welcome_notifier_spec.rb
+++ b/spec/notifiers/welcome_notifier_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe WelcomeNotifier do
+  describe ".deliver_to" do
+    it "sends at most once per user" do
+      allow(Emails::UserMailer).to receive(:welcome).and_return(double(deliver_later: nil))
+
+      user = FactoryBot.create(:user, :confirmed)
+
+      WelcomeNotifier.deliver_to(user)
+      perform_enqueued_jobs
+      WelcomeNotifier.deliver_to(user)
+      perform_enqueued_jobs
+
+      expect(Emails::UserMailer).to have_received(:welcome).with(user).once
+    end
+  end
+end

--- a/spec/notifiers/welcome_notifier_spec.rb
+++ b/spec/notifiers/welcome_notifier_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe WelcomeNotifier do
       WelcomeNotifier.deliver_to(user)
       perform_enqueued_jobs
 
-      expect(Emails::UserMailer).to have_received(:welcome).with(user).once
+      expect(Emails::UserMailer).to have_received(:welcome).with(user, :no_token).once
     end
   end
 end

--- a/spec/requests/users/confirmations_spec.rb
+++ b/spec/requests/users/confirmations_spec.rb
@@ -107,6 +107,19 @@ RSpec.describe "Confirmations", type: :request do
       expect(flash[:notice]).to eq("Thank you for confirming your email address")
     end
 
+    it "sends welcome email to user" do
+      user = FactoryBot.create(:user, :unconfirmed)
+
+      put users_confirmation_path(user.generate_token_for(:confirmation))
+
+      perform_enqueued_jobs_and_subsequently_enqueued_jobs
+
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+
+      mail = find_mail_to(user.email)
+      expect(mail.subject).to eq("Welcome to Joy of Rails!")
+    end
+
     it "disallows a user to confirm their email address with invalid token" do
       token = "invalid_token"
 

--- a/spec/requests/users/newsletter_subscriptions_spec.rb
+++ b/spec/requests/users/newsletter_subscriptions_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe "Newsletter Subscriptions", type: :request do
       user.reload
 
       expect(response).to redirect_to(root_path)
-      expect(flash[:notice]).to eq("You have been unsubscribed")
+      expect(flash[:notice]).to eq("You have been unsubscribed from the Joy of Rails newsletter")
 
       expect(user.newsletter_subscription).to be_nil
     end
@@ -249,7 +249,7 @@ RSpec.describe "Newsletter Subscriptions", type: :request do
       user.reload
 
       expect(response).to redirect_to(root_path)
-      expect(flash[:notice]).to eq("You have been unsubscribed")
+      expect(flash[:notice]).to eq("You have been unsubscribed from the Joy of Rails newsletter")
 
       expect(user.newsletter_subscription).to be_nil
     end
@@ -265,7 +265,7 @@ RSpec.describe "Newsletter Subscriptions", type: :request do
       user.reload
 
       expect(response).to redirect_to(root_path)
-      expect(flash[:notice]).to eq("You have been unsubscribed")
+      expect(flash[:notice]).to eq("You have been unsubscribed from the Joy of Rails newsletter")
 
       expect(user.newsletter_subscription).to be_nil
     end
@@ -291,7 +291,7 @@ RSpec.describe "Newsletter Subscriptions", type: :request do
       expect(user.newsletter_subscription).to be_present
 
       expect {
-        post unsubscribe_users_newsletter_subscription_path(user.newsletter_subscription.id)
+        post unsubscribe_users_newsletter_subscription_path("bad-token")
       }.not_to change(NewsletterSubscription, :count)
 
       user.reload
@@ -313,7 +313,7 @@ RSpec.describe "Newsletter Subscriptions", type: :request do
       user.reload
 
       expect(response).to redirect_to(root_path)
-      expect(flash[:notice]).to eq("You have been unsubscribed")
+      expect(flash[:notice]).to eq("You have been unsubscribed from the Joy of Rails newsletter")
 
       expect(user.newsletter_subscription).to be_nil
     end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Sessions", type: :request do
       expect(user.reload.last_sign_in_at).to be_present
     end
 
-    it "signs in unconfirmed user with valid magic session token" do
+    it "signs in and confirms unconfirmed user with valid magic session token" do
       user = FactoryBot.create(:user, :unconfirmed)
       token = user.generate_token_for(:magic_session)
       expect(user.last_sign_in_at).to be_nil
@@ -65,6 +65,13 @@ RSpec.describe "Sessions", type: :request do
 
       expect(user.last_sign_in_at).to be_present
       expect(user).to be_confirmed
+
+      perform_enqueued_jobs_and_subsequently_enqueued_jobs
+
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+
+      mail = find_mail_to(user.email)
+      expect(mail.subject).to eq("Welcome to Joy of Rails!")
     end
 
     it "disallows when user not found with given email" do


### PR DESCRIPTION
Let’s send a welcome email for new sign ups!

Adds rudimentary protection against double-sends of the welcome email. This logic hangs off a new column `processed_at`. A notification is currently consider "processed" if we've kicked off the email delivery logic which is different than saying the email was actually delivered. Currently, we’ll only send the welcome email if no welcome email notification was previously processed. If the email delivery fails for some reason, this means the welcome email might not get sent. I’d consider this "at most once" delivery which seems acceptable for a low-stakes welcome email.