### PR TITLE
Remove feature gate on confirmation actions

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Users::ConfirmationsController < ApplicationController
-  before_action :feature_enabled!
   before_action :redirect_if_authenticated, only: [:create, :new]
 
   def new
@@ -51,19 +50,15 @@ class Users::ConfirmationsController < ApplicationController
     end
 
     if @user.confirm!
-      warden.set_user(@user, scope: :user)
+      if Flipper.enabled?(:user_registration, @user)
+        warden.set_user(@user, scope: :user)
+      end
 
       WelcomeNotifier.deliver_to(@user)
 
-      redirect_to users_dashboard_path, notice: "Thank you for confirming your email address"
+      redirect_to users_thank_you_path, notice: "Thank you for confirming your email address"
     else
       redirect_to new_users_confirmation_path, alert: "Something went wrong"
     end
-  end
-
-  private
-
-  def feature_enabled!
-    redirect_to root_path, notice: "Coming soon!" unless Flipper.enabled?(:user_registration, current_admin_user)
   end
 end

--- a/app/views/emails/user_mailer/confirmation.html.erb
+++ b/app/views/emails/user_mailer/confirmation.html.erb
@@ -1,5 +1,5 @@
 <h1>Complete your Joy of Rails registration</h1>
 
 <p>
-<%= link_to "Confirm your email address", edit_users_confirmation_url(@confirmation_token) %>.
+<%= link_to "Confirm your email address", confirm_users_confirmation_url(@confirmation_token) %>.
 </p>

--- a/app/views/emails/user_mailer/confirmation.text.erb
+++ b/app/views/emails/user_mailer/confirmation.text.erb
@@ -1,3 +1,3 @@
 # Complete your Joy of Rails registration
 
-Follow this link to confirm your email address: <%= edit_users_confirmation_url(@confirmation_token) %>
+Follow this link to confirm your email address: <%= confirm_users_confirmation_url(@confirmation_token) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,11 @@ Rails.application.routes.draw do
     resource :thank_you, only: [:show]
     resource :header_navigation, only: [:show]
     resource :registration, only: [:new, :create, :edit, :update, :destroy]
-    resources :confirmations, only: [:new, :create, :edit, :update], param: :token
+    resources :confirmations, only: [:new, :create, :edit, :update], param: :token do
+      member do
+        match "confirm" => "confirmations#update", :via => [:get]
+      end
+    end
     resources :passwords, only: [:new, :create, :edit, :update], param: :token
 
     resources :newsletter_subscriptions, only: [:new, :create, :index, :show] do

--- a/spec/requests/users/confirmations_spec.rb
+++ b/spec/requests/users/confirmations_spec.rb
@@ -5,10 +5,6 @@ require "rails_helper"
 RSpec.describe "Confirmations", type: :request do
   include ActiveSupport::Testing::TimeHelpers
 
-  before do
-    Flipper[:user_registration].enable
-  end
-
   describe "POST create" do
     it "succeeds for unconfirmed user" do
       user = FactoryBot.create(:user, :unconfirmed)
@@ -103,7 +99,18 @@ RSpec.describe "Confirmations", type: :request do
 
       put users_confirmation_path(user.generate_token_for(:confirmation))
 
-      expect(response).to redirect_to(users_dashboard_path)
+      expect(response).to redirect_to(users_thank_you_path)
+      expect(flash[:notice]).to eq("Thank you for confirming your email address")
+    end
+
+    it "works when user sessions are disabled" do
+      Flipper[:user_registration].enable
+
+      user = FactoryBot.create(:user, :unconfirmed)
+
+      put users_confirmation_path(user.generate_token_for(:confirmation))
+
+      expect(response).to redirect_to(users_thank_you_path)
       expect(flash[:notice]).to eq("Thank you for confirming your email address")
     end
 

--- a/spec/system/users/confirmations_spec.rb
+++ b/spec/system/users/confirmations_spec.rb
@@ -21,8 +21,6 @@ RSpec.describe "Confirmations", type: :system do
 
     visit email_link(mail, "Confirm your email address")
 
-    click_button "Confirm email"
-
     expect(page).to have_content("Thank you for confirming your email address")
     expect(User.last).to be_confirmed
   end

--- a/spec/system/users/registrations_spec.rb
+++ b/spec/system/users/registrations_spec.rb
@@ -71,8 +71,6 @@ RSpec.describe "Registrations", type: :system do
 
     visit email_link(mail, "Confirm your email address")
 
-    click_button "Confirm email"
-
     user = User.last
     expect(user).to be_confirmed
     expect(user.email).to eq("newemail@example.com")


### PR DESCRIPTION
The feature gate was preventing new subscribers from completing the confirmation flow. This PR removes the feature gate on confirmations controller actions.

It will also allow the email confirmation link to confirm as a GET request. This may not be RESTful but will lower the friction to confirmation—one less click.
