### PR TITLE
Fix for default revision param

### DIFF
--- a/app/views/components/code_block/app_file.rb
+++ b/app/views/components/code_block/app_file.rb
@@ -3,7 +3,7 @@ class CodeBlock::AppFile < Phlex::HTML
 
   # @param filename [String] the file path or an Examples::AppFile.
   # @param file [String] the file path or an Examples::AppFile.
-  def initialize(filename, lines: nil, revision: nil, **attributes)
+  def initialize(filename, lines: nil, revision: "HEAD", **attributes)
     @app_file = Examples::AppFile.from(filename, revision: revision)
     @lines = lines
     @attributes = attributes


### PR DESCRIPTION
We don‘t want the default `:revision` param to `Examples::AppFWile` to be `nil`, otherwise the file source cannot be read. Likely a caching issue in development masked the issue prior to the last merge #180.
