### PR TITLE
Remove error prone auto focus from syntax preview

### DIFF
--- a/app/javascript/controllers/syntax-highlight/preview.js
+++ b/app/javascript/controllers/syntax-highlight/preview.js
@@ -4,8 +4,6 @@ import debug from '../../utils/debug';
 
 const console = debug('app:javascript:controllers:syntax-highlight:preview');
 
-let submitting = false;
-
 export default class extends Controller {
   static values = {
     name: String, // The name of the syntax highlight css file to enable
@@ -26,19 +24,11 @@ export default class extends Controller {
         });
         link.disabled = name !== link.dataset.syntaxHighlight;
       });
-
-    if (submitting) {
-      this.selectTarget.focus();
-      submitting = false;
-    }
   }
 
   change(event) {
     if (event.target.form) {
       event.target.form.requestSubmit();
-
-      // This is some hacky module state so that we can retain the focus on the re-rendered select element after a submit
-      submitting = true;
     }
   }
 }


### PR DESCRIPTION
The intended behavior wasn‘t consistent cross-browser so I‘m removing it.
