### PR TITLE
Fix for Newsletter edit preview

### DIFF
--- a/app/controllers/admin/newsletters_controller.rb
+++ b/app/controllers/admin/newsletters_controller.rb
@@ -17,6 +17,7 @@ class Admin::NewslettersController < ApplicationController
   # GET /admin/newsletters/1/edit
   def edit
     @newsletter = Newsletter.find(params[:id])
+    @newsletter.assign_attributes(newsletter_params)
   end
 
   # POST /admin/newsletters

--- a/app/javascript/css/utilities/custom.css
+++ b/app/javascript/css/utilities/custom.css
@@ -26,6 +26,11 @@
   padding-bottom: var(--space-3xl);
 }
 
+.mx--4 {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+
 .bg-success {
   background-color: var(--joy-background-success);
 }

--- a/app/views/admin/newsletters/_form.html.erb
+++ b/app/views/admin/newsletters/_form.html.erb
@@ -24,7 +24,7 @@
   <fieldset>
     <%= form.submit class: "button primary" %>
     <%= form.submit "Preview", class: "button secondary",
-      formaction: new_admin_newsletter_path,
+      formaction: (newsletter.persisted? ? edit_admin_newsletter_path(newsletter) : new_admin_newsletter_path),
       formmethod: "get",
       formnovalidate: true,
       data: { turbo_frame: dom_id(newsletter, :markdown) } %>

--- a/app/views/admin/newsletters/_newsletter.html.erb
+++ b/app/views/admin/newsletters/_newsletter.html.erb
@@ -1,3 +1,3 @@
-<div id="<%= dom_id newsletter %>" class="joy-border p-4">
+<div id="<%= dom_id(newsletter, :markdown) %>" class="article-content joy-border-subtle p-4 mx--4">
   <%= basic_markdown (newsletter&.content || "").html_safe %>
 </div>

--- a/app/views/admin/newsletters/show.html.erb
+++ b/app/views/admin/newsletters/show.html.erb
@@ -4,9 +4,11 @@
     <%= button_to "Send Test", deliver_admin_newsletter_path(@newsletter), method: :patch, class: "button secondary" %>
     <%= button_to "Send Live", deliver_admin_newsletter_path(@newsletter, live: true), method: :patch, class: "button primary" %>
   </div>
+  <hr>
 
   <%= render @newsletter %>
 
+  <hr>
   <div class="flex col-gap-m">
     <%= link_to "Back to newsletters", admin_newsletters_path %>
     <%= link_to "Public Show", @newsletter %>

--- a/app/views/newsletters/_newsletter.html.erb
+++ b/app/views/newsletters/_newsletter.html.erb
@@ -1,3 +1,3 @@
-<div id="<%= dom_id newsletter %>" class="joy-border p-4">
+<div id="<%= dom_id newsletter %>" class="article-content">
   <%= basic_markdown (newsletter&.content || "").html_safe %>
 </div>


### PR DESCRIPTION
The edit interaction for the Newsletter in the admin area was raising a Turbo Frame missing content error in the browser. This change ensures the preview action in the edit context is sent to the edit action and params get assigned to the Newsletter instance.

Also updates styles for the Newsletter show page.