### PR TITLE
Update color scheme analytics

### DIFF
--- a/app/controllers/concerns/analytics.rb
+++ b/app/controllers/concerns/analytics.rb
@@ -1,0 +1,16 @@
+module Analytics
+  extend ActiveSupport::Concern
+
+  def plausible_event(name, props: {})
+    Analytics::PlausibleEventJob.perform_later(
+      name: name,
+      url: request.original_url,
+      props: props,
+      referrer: request.referer,
+      headers: {
+        "User-Agent" => request.user_agent,
+        "X-Forwarded-For" => request.remote_ip
+      }
+    )
+  end
+end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -3,9 +3,6 @@ module Authentication
   extend ActiveSupport::Concern
 
   included do
-    before_action :current_admin_user
-    before_action :current_user
-
     helper_method :current_admin_user
     helper_method :current_user
     helper_method :user_signed_in?

--- a/app/controllers/settings/color_schemes_controller.rb
+++ b/app/controllers/settings/color_schemes_controller.rb
@@ -1,6 +1,4 @@
 class Settings::ColorSchemesController < ApplicationController
-  after_action :send_plausible_event, only: :update
-
   def show
     @color_scheme = find_color_scheme
 
@@ -44,24 +42,5 @@ class Settings::ColorSchemesController < ApplicationController
     end
 
     redirect_to settings_color_scheme_path, status: :see_other
-  end
-
-  private
-
-  def send_plausible_event
-    plausible_event "Color Scheme Update", props: {color_scheme: @color_scheme.name}
-  end
-
-  def plausible_event(name, props: {})
-    Analytics::PlausibleEventJob.perform_later(
-      name: name,
-      url: request.original_url,
-      props: props,
-      referrer: request.referer,
-      headers: {
-        "User-Agent" => request.user_agent,
-        "X-Forwarded-For" => request.remote_ip
-      }
-    )
   end
 end

--- a/app/views/settings/color_schemes/select.rb
+++ b/app/views/settings/color_schemes/select.rb
@@ -25,7 +25,8 @@ class Settings::ColorSchemes::Select < ApplicationComponent
               selected: previewing? && @settings.color_scheme.id
             },
             onchange: "this.form.requestSubmit()",
-            class: ""
+            class: "",
+            data: send_analytics
           )
           noscript { f.submit "Preview", class: "button primary" }
         end
@@ -35,7 +36,8 @@ class Settings::ColorSchemes::Select < ApplicationComponent
 
       link_to "I feel lucky!",
         url_for(settings: {color_scheme_id: random_curated_color_scheme_id}),
-        class: "button secondary "
+        class: "button secondary",
+        data: send_analytics
     end
   end
 
@@ -50,5 +52,9 @@ class Settings::ColorSchemes::Select < ApplicationComponent
   def random_curated_color_scheme_id
     _display_name, id = cached_curated_color_scheme_options.sample
     id
+  end
+
+  def send_analytics
+    {action: "analytics#send"}
   end
 end

--- a/app/views/settings/color_schemes/show_view.rb
+++ b/app/views/settings/color_schemes/show_view.rb
@@ -27,7 +27,7 @@ class Settings::ColorSchemes::ShowView < ApplicationView
     render Pages::Header.new(title: "Settings: Color Scheme")
 
     section(class: "section-content container py-gap") do
-      turbo_frame_tag "color-scheme-form", data: {turbo_action: "advance"} do
+      turbo_frame_tag "color-scheme-form", data: {turbo_action: "advance", controller: "analytics", analytics_event_value: "Color Scheme Update"} do
         style do
           render(ColorSchemes::Css.new(color_scheme: @session_color_scheme)) if @session_color_scheme
           render(ColorSchemes::Css.new(color_scheme: @color_scheme, my_theme_enabled: true))
@@ -122,7 +122,8 @@ class Settings::ColorSchemes::ShowView < ApplicationView
     button_to "Save #{@preview_color_scheme.display_name}",
       settings_color_scheme_path(settings: {color_scheme_id: @preview_color_scheme.id}),
       method: :patch,
-      class: "button primary"
+      class: "button primary",
+      data: send_analytics
   end
 
   def unsave_button
@@ -130,7 +131,8 @@ class Settings::ColorSchemes::ShowView < ApplicationView
       settings_color_scheme_path(settings: {color_scheme_id: ColorScheme.cached_default.id}),
       method: :patch,
       class: "button warn",
-      style: "min-width: 25ch;"
+      style: "min-width: 25ch;",
+      data: {confirm: "Are you sure you want to delete your saved color scheme?", **send_analytics}
   end
 
   def reset_button
@@ -164,5 +166,9 @@ class Settings::ColorSchemes::ShowView < ApplicationView
 
   def inline_style_header_color(color_scheme)
     "color: var(--color-#{color_scheme.name.parameterize}-500)"
+  end
+
+  def send_analytics
+    {action: "analytics#send"}
   end
 end

--- a/spec/controllers/analytics_spec.rb
+++ b/spec/controllers/analytics_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "Analytics", type: :controller do
+  controller do
+    include Analytics
+
+    after_action do
+      plausible_event "Something Happened", props: {value: 42}
+    end
+
+    def index
+      render plain: "Hello, World!"
+    end
+  end
+
+  it "sends a plausible event" do
+    plausible_request = stub_request(:post, "https://plausible.io/api/event")
+
+    get :index
+
+    perform_enqueued_jobs
+
+    expect(plausible_request).to have_been_requested
+  end
+end

--- a/spec/requests/settings/color_schemes_spec.rb
+++ b/spec/requests/settings/color_schemes_spec.rb
@@ -106,15 +106,5 @@ RSpec.describe "Settings Color Schemes", type: :request do
         expect(response.body).to match("--color-#{default_color_scheme.name.parameterize}")
       end
     end
-
-    it "sends a plausible event" do
-      plausible_request = stub_request(:post, "https://plausible.io/api/event")
-
-      patch settings_color_scheme_path(settings: {color_scheme_id: color_scheme.id})
-
-      perform_enqueued_jobs
-
-      expect(plausible_request).to have_been_requested
-    end
   end
 end


### PR DESCRIPTION
Color scheme events sent from the controller do not appear consistently in Plausible. There may be a fix needed for properly sending events from the backend but I am punting on investigating. This PR moves color scheme events into the frontend, extracts an analytics concern for future troubleshooting on the backend.

I also included a small change to avoid eagerly calling `current_user` and `current_admin_user` in before actions on every request.
