### PR TITLE
Render basic code block from app file within atom

### DIFF
--- a/app/controllers/feed_controller.rb
+++ b/app/controllers/feed_controller.rb
@@ -3,8 +3,7 @@ class FeedController < ApplicationController
     @articles = ArticlePage.published
     respond_to do |format|
       format.html { redirect_to feed_path(format: :atom), status: :moved_permanently }
-      # format.xml { headers["Content-Type"] = 'application/rss+xml; charset=utf-8'}
-      format.atom { headers["Content-Type"] = "application/atom+xml; charset=utf-8" }
+      format.atom
     end
   end
 end

--- a/app/models/examples/app_file.rb
+++ b/app/models/examples/app_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Examples
   class AppFile
     class << self

--- a/app/views/components/atom/entry_content.rb
+++ b/app/views/components/atom/entry_content.rb
@@ -50,7 +50,7 @@ class Atom::EntryContent
       inline: article.body,
       type: :"mdrb-atom",
       layout: false,
-      content_type: article.mime_type.to_s,
+      content_type: "application/atom+xml",
       assigns: {
         format: :atom
       }

--- a/app/views/components/code_block/app_file.rb
+++ b/app/views/components/code_block/app_file.rb
@@ -10,6 +10,11 @@ class CodeBlock::AppFile < ApplicationComponent
   end
 
   def view_template
+    # When an AppFile code block renders within an Atom feed, we want to render the basic code block
+    if content_type?("application/atom+xml")
+      return render ::CodeBlock::Basic.new(source, **attributes)
+    end
+
     render ::CodeBlock::Article.new(**attributes) do |code_block|
       code_block.title do
         link(app_file.repo_url, "Source code on Github", class: "nc") {
@@ -30,5 +35,9 @@ class CodeBlock::AppFile < ApplicationComponent
 
   def source
     app_file.source(lines: lines)
+  end
+
+  def content_type?(type)
+    helpers.headers["Content-Type"].to_s =~ %r{#{Regexp.escape(type)}}
   end
 end

--- a/app/views/components/markdown/allows_erb.rb
+++ b/app/views/components/markdown/allows_erb.rb
@@ -1,3 +1,6 @@
+# DANGER! This parses Erb, which means arbitrary Ruby can be run. Make sure
+# you trust the source of your markdown and that its not user input.
+
 module Markdown::AllowsErb
   ERB_TAGS = %r{s*<%.*?%>}
   ERB_TAGS_START = %r{\A<%.*?%>}

--- a/app/views/components/markdown/atom.rb
+++ b/app/views/components/markdown/atom.rb
@@ -1,6 +1,3 @@
-# DANGER! This parses Erb, which means arbitrary Ruby can be run. Make sure
-# you trust the source of your markdown and that its not user input.
-
 class Markdown::Atom < Markdown::Application
   prepend Markdown::AllowsErb
 end

--- a/app/views/feed/index.atom.builder
+++ b/app/views/feed/index.atom.builder
@@ -9,7 +9,7 @@ atom_feed do |feed|
       url: request.base_url + article.request_path
     ) do |entry|
       entry.title(article.title)
-      entry.content(Atom::EntryContent.new(article).render, type: "html")
+      entry.content(Atom::EntryContent.new(article, request: request).render, type: "html")
 
       entry.author do |author|
         author.name(article.author)

--- a/spec/views/components/code_block/app_file_spec.rb
+++ b/spec/views/components/code_block/app_file_spec.rb
@@ -5,12 +5,17 @@ RSpec.describe CodeBlock::AppFile, type: :view do
     Capybara.string(render(*, **))
   end
 
+  before do
+    allow(view).to receive(:headers).and_return({"Content-Type" => "text/html"})
+  end
+
   it "renders contents of file" do
     page = render_page(CodeBlock::AppFile.new("config/database.yml"))
     expect(page).to have_content(<<~YAML)
       default: &default
         adapter: sqlite3
     YAML
+    expect(page).to have_content("config/database.yml")
   end
 
   it "renders contents of file by line number" do
@@ -41,5 +46,17 @@ RSpec.describe CodeBlock::AppFile, type: :view do
 
     expect(page).to have_content("database: storage/production/data.sqlite3")
     expect(page).not_to have_content("database: storage/development/data.sqlite3")
+  end
+
+  it "renders basic code block when content type is atom" do
+    allow(view).to receive(:headers).and_return({"Content-Type" => "application/atom+xml"})
+
+    page = render_page(CodeBlock::AppFile.new("config/database.yml"))
+    expect(page).to have_content(<<~YAML)
+      default: &default
+        adapter: sqlite3
+    YAML
+
+    expect(page).not_to have_content("config/database.yml")
   end
 end


### PR DESCRIPTION
When a `CodeBlock::AppFile` is rendered in an mdrb file, it adds some html elements ideal for viewing in a browser, like the green-yellow-red app dots, link to file, and copy button.

In an atom feed, the extra elements don’t look as good and the copy button is non-functional:

![Screenshot 2024-08-16 at 8 59 32 AM](https://github.com/user-attachments/assets/4f082746-69d1-4df4-9ebe-d5ea68dc9b96)

This change adds detection of the atom format with the `CodeBlock::AppFile` component to render the basic code block instead.

We manually set the ApplicationController renderer to `atom+xml` content type within the `Atom::EntryFeed` (since the rendering context doesn‘t carryover to the ApplicationController renderer when we render the article content into the feed).