### PR TITLE
Bump rexml from 3.3.4 to 3.3.6 in the bundler group across 1 directory

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,7 +393,7 @@ GEM
     reline (0.5.9)
       io-console (~> 0.5)
     require_all (3.0.0)
-    rexml (3.3.4)
+    rexml (3.3.6)
       strscan
     rouge (4.3.0)
     rspec-core (3.13.0)


### PR DESCRIPTION
Bumps the bundler group with 1 update in the / directory: [rexml](https://github.com/ruby/rexml).


Updates `rexml` from 3.3.4 to 3.3.6
- [Release notes](https://github.com/ruby/rexml/releases)
- [Changelog](https://github.com/ruby/rexml/blob/master/NEWS.md)
- [Commits](https://github.com/ruby/rexml/compare/v3.3.4...v3.3.6)

---
updated-dependencies:
- dependency-name: rexml dependency-type: indirect dependency-group: bundler ...

<!-- Describe your changes and link to relevant issues or discussions. Please add motivation and context as needed. -->

## Pull request checklist

- [ ] I have written tests for code I have added or modified.
- [ ] I linted and tested the project with `bin/verify`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
