### PR TITLE
Update snippet screenshot dimensions

### DIFF
--- a/app/content/layouts/article.html.erb
+++ b/app/content/layouts/article.html.erb
@@ -33,7 +33,7 @@
         </nav>
       </aside>
     <%- end -%>
-    <div class="article-content container" itemprop="articleBody">
+    <div class="article-content container mb-3xl" itemprop="articleBody">
       <%= yield %>
     </div>
   </article>

--- a/app/controllers/share/snippet_screenshots_controller.rb
+++ b/app/controllers/share/snippet_screenshots_controller.rb
@@ -15,6 +15,6 @@ class Share::SnippetScreenshotsController < ApplicationController
   def create
     @snippet = Snippet.find(params[:snippet_id])
     @snippet.attach_screenshot_from_base64(params[:screenshot])
-    redirect_to new_share_snippet_tweet_path(@snippet, auto: true), notice: "Screenshot attached".emojoy
+    redirect_to new_share_snippet_tweet_path(@snippet, auto: true), notice: "Screenshot successful".emojoy
   end
 end

--- a/app/controllers/share/snippet_screenshots_controller.rb
+++ b/app/controllers/share/snippet_screenshots_controller.rb
@@ -9,6 +9,7 @@ class Share::SnippetScreenshotsController < ApplicationController
 
   def new
     @snippet = Snippet.find(params[:snippet_id])
+    @auto = params[:auto] == "true"
   end
 
   def create

--- a/app/controllers/share/snippets_controller.rb
+++ b/app/controllers/share/snippets_controller.rb
@@ -67,7 +67,7 @@ class Share::SnippetsController < ApplicationController
   def share_snippet_redirect_url(snippet)
     case params[:commit]
     when "Share"
-      new_share_snippet_screenshot_url(snippet)
+      new_share_snippet_screenshot_url(snippet, auto: true)
     else
       edit_share_snippet_url(snippet)
     end

--- a/app/controllers/share/snippets_controller.rb
+++ b/app/controllers/share/snippets_controller.rb
@@ -66,7 +66,9 @@ class Share::SnippetsController < ApplicationController
 
   def share_snippet_redirect_url(snippet)
     case params[:commit]
-    when "Share"
+    when /Close/
+      share_snippet_url(snippet)
+    when /Share/
       new_share_snippet_screenshot_url(snippet, auto: true)
     else
       edit_share_snippet_url(snippet)

--- a/app/javascript/controllers/snippets/screenshot.ts
+++ b/app/javascript/controllers/snippets/screenshot.ts
@@ -6,10 +6,15 @@ import debug from '../../utils/debug';
 const console = debug('app:javascript:controllers:snippets:screenshot');
 
 export default class extends Controller<HTMLFormElement> {
+  static values = {
+    auto: Boolean,
+  };
+
   static targets = ['snippet', 'submitButton'];
 
   declare readonly snippetTarget: HTMLInputElement;
   declare readonly submitButtonTarget: HTMLInputElement;
+  declare readonly autoValue: boolean;
 
   connect(): void {
     console.log('Connect!');
@@ -19,9 +24,11 @@ export default class extends Controller<HTMLFormElement> {
       this.prepareScreenshot,
     );
 
-    // submit immediately
-    this.submitButtonTarget.click();
-    this.submitButtonTarget.disabled = true;
+    if (this.autoValue) {
+      // submit immediately
+      this.submitButtonTarget.click();
+      this.submitButtonTarget.disabled = true;
+    }
   }
 
   prepareScreenshot = async (event) => {

--- a/app/javascript/controllers/snippets/tweet.ts
+++ b/app/javascript/controllers/snippets/tweet.ts
@@ -5,6 +5,22 @@ import debug from '../../utils/debug';
 
 const console = debug('app:javascript:controllers:snippets:tweet');
 
+const WINDOW_OPTIONS = {
+  width: 550,
+  height: 420,
+  toolbar: false,
+  location: false,
+  directories: false,
+  status: false,
+  menubar: false,
+  scrollbars: true,
+  copyhistory: false,
+  resizable: true,
+};
+
+const WINDOW_OPTIONS_ARGUMENT = Object.entries(WINDOW_OPTIONS)
+  .map(([key, value]) => `${key}=${value}`)
+  .join(',');
 export default class extends Controller {
   static values = {
     url: String,
@@ -32,10 +48,6 @@ export default class extends Controller {
 
     const tweetUrl = `https://x.com/intent/post?text=${tweetText}`;
 
-    window.open(
-      tweetUrl,
-      '_blank',
-      'width=550,height=420,toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=yes',
-    );
+    window.open(tweetUrl, '_blank', WINDOW_OPTIONS_ARGUMENT);
   }
 }

--- a/app/javascript/controllers/snippets/tweet.ts
+++ b/app/javascript/controllers/snippets/tweet.ts
@@ -1,3 +1,4 @@
+import { Turbo } from '@hotwired/turbo-rails';
 import { Controller } from '@hotwired/stimulus';
 
 import debug from '../../utils/debug';
@@ -18,6 +19,7 @@ export default class extends Controller {
 
     if (this.autoValue) {
       this.tweet();
+      Turbo.visit(this.urlValue);
     }
   }
 

--- a/app/javascript/css/components/article-content.css
+++ b/app/javascript/css/components/article-content.css
@@ -1,7 +1,5 @@
 .article-content,
 .section-content {
-  padding-bottom: var(--space-3xl);
-
   & h1,
   & h2,
   & h3,

--- a/app/javascript/css/components/code.scss
+++ b/app/javascript/css/components/code.scss
@@ -4,7 +4,6 @@
   --code-line-height: 1.7777778;
 
   border-radius: var(--space-3xs-2xs);
-  border: 1px solid var(--joy-border-quiet);
 
   & input,
   & textarea {

--- a/app/javascript/css/components/snippet.css
+++ b/app/javascript/css/components/snippet.css
@@ -1,7 +1,7 @@
 .snippet {
   filter: drop-shadow(0 0 0.75rem var(--joy-color-50));
   width: fit-content;
-  max-width: var(--grid-max-width);
+  max-width: var(--grid-max-width) - (2 * var(--grid-gutter));
 
   & .code-editor {
     padding-top: var(--space-xs);
@@ -15,7 +15,18 @@
   background-color: var(--joy-color-200);
   padding: var(--space-l);
   width: fit-content;
+  aspect-ratio: 2 / 1;
   border-radius: 0.5rem;
+  max-width: var(--grid-max-width);
+  overflow-x: clip;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  & .code-wrapper {
+    margin: 0 auto;
+  }
 }
 
 /*

--- a/app/javascript/css/components/snippet.css
+++ b/app/javascript/css/components/snippet.css
@@ -1,5 +1,5 @@
 .snippet {
-  filter: drop-shadow(0 0 0.75rem var(--joy-color-50));
+  filter: drop-shadow(0.25rem 0.5rem 0.75rem var(--joy-color-500));
   width: fit-content;
   max-width: var(--grid-max-width) - (2 * var(--grid-gutter));
 
@@ -9,10 +9,20 @@
     padding-bottom: var(--space-m);
     padding-inline-start: var(--space-m);
   }
+
+  & .clipboard-copy-container {
+    position: absolute;
+    right: 0px;
+    display: none;
+  }
+
+  &:hover .clipboard-copy-container {
+    display: block;
+  }
 }
 
 .snippet-background {
-  background-color: var(--joy-color-200);
+  background: linear-gradient(var(--joy-color-300), var(--joy-color-200));
   padding: var(--space-l);
   width: fit-content;
   aspect-ratio: 2 / 1;

--- a/app/javascript/css/utilities/custom.css
+++ b/app/javascript/css/utilities/custom.css
@@ -2,6 +2,10 @@
   margin-bottom: var(--grid-gutter);
 }
 
+.mb-xl {
+  margin-bottom: var(--space-xl);
+}
+
 .mb-3xl {
   margin-bottom: var(--space-3xl);
 }

--- a/app/javascript/css/utilities/custom.css
+++ b/app/javascript/css/utilities/custom.css
@@ -2,8 +2,8 @@
   margin-bottom: var(--grid-gutter);
 }
 
-.mb-gap {
-  margin-bottom: var(--grid-gutter);
+.mb-3xl {
+  margin-bottom: var(--space-3xl);
 }
 
 .py-gap {

--- a/app/views/admin/newsletters/edit.html.erb
+++ b/app/views/admin/newsletters/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render Pages::Header.new(title: "Newsletter: Edit") %>
-<div class="section-content container py-gap">
+<div class="section-content container py-gap mb-3xl">
   <%= render "form", newsletter: @newsletter %>
 
   <div>

--- a/app/views/admin/newsletters/index.html.erb
+++ b/app/views/admin/newsletters/index.html.erb
@@ -1,5 +1,5 @@
 <%= render Pages::Header.new(title: "Admin: Newsletters") %>
-<div class="section-content container py-gap">
+<div class="section-content container py-gap mb-3xl">
   <div class="flex">
     <%= link_to "New newsletter", new_admin_newsletter_path, class: "button primary" %>
   </div>

--- a/app/views/admin/newsletters/new.html.erb
+++ b/app/views/admin/newsletters/new.html.erb
@@ -1,5 +1,5 @@
 <%= render Pages::Header.new(title: "Admin: Create Newsletter") %>
-<div class="section-content container py-gap">
+<div class="section-content container py-gap mb-3xl">
   <%= render "form", newsletter: @newsletter %>
 
   <div>

--- a/app/views/admin/newsletters/show.html.erb
+++ b/app/views/admin/newsletters/show.html.erb
@@ -1,5 +1,5 @@
 <%= render Pages::Header.new(title: "Admin: #{@newsletter.title}") %>
-<div class="section-content container py-gap">
+<div class="section-content container py-gap mb-3xl">
   <div class="flex gap-x-2">
     <%= button_to "Send Test", deliver_admin_newsletter_path(@newsletter), method: :patch, class: "button secondary" %>
     <%= button_to "Send Live", deliver_admin_newsletter_path(@newsletter, live: true), method: :patch, class: "button primary" %>

--- a/app/views/color_schemes/index_view.rb
+++ b/app/views/color_schemes/index_view.rb
@@ -10,7 +10,7 @@ class ColorSchemes::IndexView < ApplicationView
   def view_template
     render Pages::Header.new(title: "Color Scheme Index")
 
-    section(class: "section-content container py-gap") do
+    section(class: "section-content container py-gap mb-3xl") do
       div(class: "grid grid-content") do
         @color_schemes.each do |color_scheme|
           style do

--- a/app/views/color_schemes/show_view.rb
+++ b/app/views/color_schemes/show_view.rb
@@ -12,7 +12,7 @@ class ColorSchemes::ShowView < ApplicationView
   def view_template
     render Pages::Header.new(title: "Color Scheme: #{@color_scheme.display_name}")
 
-    section(class: "section-content container py-gap") do
+    section(class: "section-content container py-gap mb-3xl") do
       style do
         render(ColorSchemes::Css.new(color_scheme: @color_scheme, my_theme_enabled: true))
       end

--- a/app/views/components/code_block/snippet.rb
+++ b/app/views/components/code_block/snippet.rb
@@ -13,7 +13,7 @@ class CodeBlock::Snippet < ApplicationComponent
 
   def view_template
     div(class: "snippet-background", **options) do
-      render CodeBlock::Container.new(language: language) do
+      render CodeBlock::Container.new(language: language, class: "snippet") do
         render CodeBlock::Header.new { title_content } if title_content.present?
 
         render CodeBlock::Body.new do

--- a/app/views/examples/posts/index_view.rb
+++ b/app/views/examples/posts/index_view.rb
@@ -18,7 +18,7 @@ class Examples::Posts::IndexView < ApplicationView
       description: "This is an example for creating a post of different types, like text, link, or image."
     )
 
-    div(class: "section-content container py-gap") do
+    div(class: "section-content container py-gap mb-3xl") do
       link_to "New Post", new_examples_post_path, class: "button primary", data: {turbo_frame: "examples_post_form"}
 
       turbo_frame_tag :examples_post_form

--- a/app/views/examples/posts/new_view.rb
+++ b/app/views/examples/posts/new_view.rb
@@ -16,7 +16,7 @@ class Examples::Posts::NewView < ApplicationView
       description: "This is an example for creating a post of different types, like text, link, or image."
     )
 
-    div(class: "section-content container py-gap") do
+    div(class: "section-content container py-gap mb-3xl") do
       turbo_frame_tag :examples_post_form do
         render Examples::Posts::Form.new(post: @post)
       end

--- a/app/views/newsletters/index.html.erb
+++ b/app/views/newsletters/index.html.erb
@@ -1,5 +1,5 @@
 <%= render Pages::Header.new(title: "Joy of Rails Newsletter") %>
-<div class="section-content container py-gap">
+<div class="section-content container py-gap mb-3xl">
   <div class="only:inherit grid grid-row-mid">
     <h2>No newsletters have been sent yet!</h2>
     <div>

--- a/app/views/newsletters/show.html.erb
+++ b/app/views/newsletters/show.html.erb
@@ -1,4 +1,4 @@
 <%= render Pages::Header.new(title: @newsletter.title, published_on: @newsletter.sent_at&.to_date) %>
-<div class="section-content container py-gap">
+<div class="section-content container py-gap mb-3xl">
   <%= render @newsletter %>
 </div>

--- a/app/views/settings/color_schemes/preview_view.rb
+++ b/app/views/settings/color_schemes/preview_view.rb
@@ -25,7 +25,7 @@ class Settings::ColorSchemes::PreviewView < ApplicationView
   def view_template
     render Pages::Header.new(title: "Settings: Color Scheme Preview")
 
-    section(class: "section-content container py-gap") do
+    section(class: "section-content container py-gap mb-3xl") do
       turbo_frame_tag "color-scheme-preview", data: {turbo_action: "advance"} do
         style do
           render(ColorSchemes::Css.new(color_scheme: @color_scheme, my_theme_enabled: true))

--- a/app/views/settings/color_schemes/show_view.rb
+++ b/app/views/settings/color_schemes/show_view.rb
@@ -26,7 +26,7 @@ class Settings::ColorSchemes::ShowView < ApplicationView
   def view_template
     render Pages::Header.new(title: "Settings: Color Scheme")
 
-    section(class: "section-content container py-gap") do
+    section(class: "section-content container py-gap mb-3xl") do
       turbo_frame_tag "color-scheme-form", data: {turbo_action: "advance", controller: "analytics", analytics_event_value: "Color Scheme Update"} do
         style do
           render(ColorSchemes::Css.new(color_scheme: @session_color_scheme)) if @session_color_scheme

--- a/app/views/settings/syntax_highlights/show_view.rb
+++ b/app/views/settings/syntax_highlights/show_view.rb
@@ -18,7 +18,7 @@ class Settings::SyntaxHighlights::ShowView < ApplicationView
   def view_template
     render Pages::Header.new(title: "Settings: Syntax Highlighting")
 
-    section(class: %(section-content container py-gap)) do
+    section(class: %(section-content container py-gap mb-3xl)) do
       turbo_frame_tag "syntax-highlight-form" do
         render Settings::SyntaxHighlights::Form.new(
           settings: @settings,

--- a/app/views/share/snippet_screenshots/form.rb
+++ b/app/views/share/snippet_screenshots/form.rb
@@ -6,8 +6,9 @@ class Share::SnippetScreenshots::Form < ApplicationComponent
 
   attr_accessor :snippet
 
-  def initialize(snippet)
+  def initialize(snippet, auto: false)
     @snippet = snippet
+    @auto = auto
   end
 
   def view_template
@@ -17,7 +18,8 @@ class Share::SnippetScreenshots::Form < ApplicationComponent
       method: :post,
       class: "grid-content",
       data: {
-        controller: "snippet-screenshot"
+        controller: "snippet-screenshot",
+        snippet_screenshot_auto_value: auto?.to_s
       }
     ) do |form|
       errors
@@ -48,4 +50,6 @@ class Share::SnippetScreenshots::Form < ApplicationComponent
       end
     end
   end
+
+  def auto? = !!@auto
 end

--- a/app/views/share/snippet_screenshots/form.rb
+++ b/app/views/share/snippet_screenshots/form.rb
@@ -27,7 +27,9 @@ class Share::SnippetScreenshots::Form < ApplicationComponent
       render CodeBlock::Snippet.new(snippet, screenshot: true, data: {snippet_screenshot_target: "snippet"})
 
       fieldset do
-        plain form.button "Share", class: "button primary", data: {snippet_screenshot_target: "submitButton"}
+        plain form.button "Share",
+          class: "button primary",
+          data: {snippet_screenshot_target: "submitButton"}
       end
     end
   end

--- a/app/views/share/snippet_screenshots/new.html.erb
+++ b/app/views/share/snippet_screenshots/new.html.erb
@@ -1,6 +1,6 @@
 <%= render Pages::Header.new(title: "Share Snippet: Screenshot") %>
 <div class="section-content container py-gap mb-3xl">
-  <%= turbo_frame_tag :snippet_form, data: {turbo_action: "advance"} do %>
+  <%= turbo_frame_tag :snippet_form do %>
     <%= render Share::SnippetScreenshots::Form.new(@snippet, auto: @auto) %>
   <% end %>
 

--- a/app/views/share/snippet_screenshots/new.html.erb
+++ b/app/views/share/snippet_screenshots/new.html.erb
@@ -1,7 +1,7 @@
 <%= render Pages::Header.new(title: "Share Snippet: Screenshot") %>
 <div class="section-content container py-gap mb-3xl">
   <%= turbo_frame_tag :snippet_form, data: {turbo_action: "advance"} do %>
-    <%= render Share::SnippetScreenshots::Form.new(@snippet) %>
+    <%= render Share::SnippetScreenshots::Form.new(@snippet, auto: @auto) %>
   <% end %>
 
   <br>

--- a/app/views/share/snippet_screenshots/new.html.erb
+++ b/app/views/share/snippet_screenshots/new.html.erb
@@ -1,5 +1,5 @@
 <%= render Pages::Header.new(title: "Share Snippet: Screenshot") %>
-<div class="section-content container py-gap">
+<div class="section-content container py-gap mb-3xl">
   <%= turbo_frame_tag :snippet_form, data: {turbo_action: "advance"} do %>
     <%= render Share::SnippetScreenshots::Form.new(@snippet) %>
   <% end %>

--- a/app/views/share/snippet_tweets/new.html.erb
+++ b/app/views/share/snippet_tweets/new.html.erb
@@ -1,8 +1,10 @@
 <%= render Pages::Header.new(title: "Share Snippet") %>
 <div class="section-content container py-gap mb-3xl">
-  <%= turbo_frame_tag :snippet_form, data: {turbo_action: "advance"} do %>
+  <%= turbo_frame_tag :snippet_form do %>
     <%= render Share::SnippetTweets::Tweet.new(@snippet, auto: @auto) %>
   <% end %>
+
+  <br>
 
   <div>
     <%= link_to "Back to snippets", share_snippets_path %>

--- a/app/views/share/snippet_tweets/new.html.erb
+++ b/app/views/share/snippet_tweets/new.html.erb
@@ -1,5 +1,5 @@
 <%= render Pages::Header.new(title: "Share Snippet") %>
-<div class="section-content container py-gap">
+<div class="section-content container py-gap mb-3xl">
   <%= turbo_frame_tag :snippet_form, data: {turbo_action: "advance"} do %>
     <%= render Share::SnippetTweets::Tweet.new(@snippet, auto: @auto) %>
   <% end %>

--- a/app/views/share/snippet_tweets/tweet.rb
+++ b/app/views/share/snippet_tweets/tweet.rb
@@ -31,7 +31,7 @@ class Share::SnippetTweets::Tweet < ApplicationComponent
   end
 
   def tweet_url
-    @snippet.screenshot.attached? ? rails_storage_proxy_url(@snippet.screenshot) : share_snippet_url(@snippet)
+    share_snippet_url(@snippet)
   end
 
   def auto? = !!@auto

--- a/app/views/share/snippet_tweets/tweet.rb
+++ b/app/views/share/snippet_tweets/tweet.rb
@@ -23,8 +23,8 @@ class Share::SnippetTweets::Tweet < ApplicationComponent
       )
 
       flex_block do
-        button_tag "Tweet",
-          class: class_names("button", "primary", hidden: auto?),
+        button_tag "Share",
+          class: class_names("button", "primary"),
           data: {action: "click->snippet-tweet#tweet"}
       end
     end

--- a/app/views/share/snippets/edit.html.erb
+++ b/app/views/share/snippets/edit.html.erb
@@ -4,6 +4,8 @@
     <%= render Share::Snippets::Form.new(@snippet) %>
   <% end %>
 
+  <br>
+
   <div>
     <%= link_to "Show this snippet", share_snippet_path(@snippet) %> |
     <%= link_to "Back to snippets", share_snippets_path %>

--- a/app/views/share/snippets/edit.html.erb
+++ b/app/views/share/snippets/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render Pages::Header.new(title: "Snippet Share") %>
-<div class="section-content container py-gap">
+<div class="section-content container py-gap mb-3xl">
   <%= turbo_frame_tag :snippet_form do %>
     <%= render Share::Snippets::Form.new(@snippet) %>
   <% end %>

--- a/app/views/share/snippets/form.rb
+++ b/app/views/share/snippets/form.rb
@@ -52,9 +52,13 @@ class Share::Snippets::Form < ApplicationComponent
 
         fieldset do
           flex_block do
+            language_select(form, data: {action: "change->snippet-preview#preview"})
+
             plain form.submit "Share", class: "button primary"
 
             plain form.submit "Save", class: "button secondary"
+
+            plain form.submit "Save & Close", class: "button secondary"
 
             plain form.submit "Preview",
               class: "button secondary hidden",
@@ -65,13 +69,12 @@ class Share::Snippets::Form < ApplicationComponent
                 snippet_preview_target: "previewButton",
                 turbo_frame: dom_id(snippet, :code_block)
               }
-
-            language_select(form, data: {action: "change->snippet-preview#preview"})
           end
         end
       end
 
       if @snippet.persisted?
+        br
         br
         div do
           flex_block do

--- a/app/views/share/snippets/form.rb
+++ b/app/views/share/snippets/form.rb
@@ -15,7 +15,7 @@ class Share::Snippets::Form < ApplicationComponent
 
   def view_template
     turbo_stream.update "flash", partial: "application/flash"
-    div(class: "section-content") do
+    div do
       form_with(
         model: [:share, snippet],
         class: "section-content",

--- a/app/views/share/snippets/form.rb
+++ b/app/views/share/snippets/form.rb
@@ -15,10 +15,10 @@ class Share::Snippets::Form < ApplicationComponent
 
   def view_template
     turbo_stream.update "flash", partial: "application/flash"
-    div(class: "grid-content") do
+    div(class: "section-content") do
       form_with(
         model: [:share, snippet],
-        class: "grid-content",
+        class: "section-content",
         data: {
           controller: "snippet-preview",
           action: "snippet-editor:edit-finish->snippet-preview#preview"
@@ -26,25 +26,23 @@ class Share::Snippets::Form < ApplicationComponent
       ) do |form|
         errors
 
-        div(class: "grid-cols-12") do
-          div(class: "snippet-background") do
-            render CodeBlock::Container.new(language: language, class: "snippet") do
-              render CodeBlock::Header.new do
-                label(class: "sr-only", for: "snippet[filename]") { "Filename" }
-                input(type: "text", name: "snippet[filename]", value: filename)
-              end
+        div(class: "snippet-background") do
+          render CodeBlock::Container.new(language: language, class: "snippet") do
+            render CodeBlock::Header.new do
+              label(class: "sr-only", for: "snippet[filename]") { "Filename" }
+              input(type: "text", name: "snippet[filename]", value: filename)
+            end
 
-              turbo_frame_tag dom_id(snippet, :code_block) do
-                render CodeBlock::Body.new(data: {controller: "snippet-editor"}) do
-                  div(class: "grid-stack") do
-                    render CodeBlock::Code.new(source, language: language, data: {snippet_editor_target: "source"})
-                    label(class: "sr-only", for: "snippet[source]") { "Source" }
-                    div(class: "code-editor autogrow-wrapper") do
-                      textarea(
-                        name: "snippet[source]",
-                        data: {snippet_editor_target: "textarea"}
-                      ) { source }
-                    end
+            turbo_frame_tag dom_id(snippet, :code_block) do
+              render CodeBlock::Body.new(data: {controller: "snippet-editor"}) do
+                div(class: "grid-stack") do
+                  render CodeBlock::Code.new(source, language: language, data: {snippet_editor_target: "source"})
+                  label(class: "sr-only", for: "snippet[source]") { "Source" }
+                  div(class: "code-editor autogrow-wrapper") do
+                    textarea(
+                      name: "snippet[source]",
+                      data: {snippet_editor_target: "textarea"}
+                    ) { source }
                   end
                 end
               end
@@ -74,12 +72,15 @@ class Share::Snippets::Form < ApplicationComponent
       end
 
       if @snippet.persisted?
-        flex_block do
-          button_to "Destroy this snippet",
-            share_snippet_path(@snippet), method: :delete,
-            data: {confirm: "Are you sure?"},
-            class: "button warn",
-            form: {style: "margin-left: auto"} # move to the right
+        br
+        div do
+          flex_block do
+            button_to "Destroy this snippet",
+              share_snippet_path(@snippet), method: :delete,
+              data: {confirm: "Are you sure?"},
+              class: "button warn"
+            # form: {style: "margin-left: auto"} # move to the right
+          end
         end
       end
     end

--- a/app/views/share/snippets/index.html.erb
+++ b/app/views/share/snippets/index.html.erb
@@ -1,5 +1,5 @@
 <%= render Pages::Header.new(title: "Snippet Share") %>
-<div id="snippets" class="section-content container py-gap">
+<div id="snippets" class="section-content container py-gap mb-3xl">
   <% if Flipper.enabled?(:snippets, current_user) %>
     <div class="flex">
       <%= link_to "New Snippet", new_share_snippet_path, class: "button primary" %>
@@ -7,7 +7,7 @@
   <% end %>
 
   <% @snippets.each do |snippet| %>
-    <div id="<%= dom_id(snippet) %>" class="section-content">
+    <div id="<%= dom_id(snippet) %>" class="section-content mb-xl">
       <%= link_to share_snippet_path(snippet), class: "block" do %>
         <%= render CodeBlock::Snippet.new(snippet) %>
       <% end %>

--- a/app/views/share/snippets/new.html.erb
+++ b/app/views/share/snippets/new.html.erb
@@ -1,6 +1,6 @@
 <%= render Pages::Header.new(title: "Snippet Share") %>
 <div class="section-content container py-gap mb-3xl">
-  <%= turbo_frame_tag :snippet_form, data: {turbo_action: "advance"} do %>
+  <%= turbo_frame_tag :snippet_form, data: {turbo_action: "replace"} do %>
     <%= render Share::Snippets::Form.new(@snippet) %>
   <% end %>
 

--- a/app/views/share/snippets/new.html.erb
+++ b/app/views/share/snippets/new.html.erb
@@ -1,5 +1,5 @@
 <%= render Pages::Header.new(title: "Snippet Share") %>
-<div class="section-content container py-gap">
+<div class="section-content container py-gap mb-3xl">
   <%= turbo_frame_tag :snippet_form, data: {turbo_action: "advance"} do %>
     <%= render Share::Snippets::Form.new(@snippet) %>
   <% end %>

--- a/app/views/share/snippets/show.html.erb
+++ b/app/views/share/snippets/show.html.erb
@@ -12,13 +12,15 @@
 
 <%= render Pages::Header.new(title: "Snippet Share") %>
 <div class="section-content container py-gap mb-3xl">
-  <%= turbo_frame_tag :snippet_form, data: {turbo_action: "advance"} do %>
+  <%= turbo_frame_tag :snippet_form do %>
     <%= render CodeBlock::Snippet.new(@snippet) %>
   <% end %>
 
   <div>
     <%= render Share::Snippets::Toolbar.new(@snippet, current_user: current_user) %>
   </div>
+
+  <br>
 
   <div>
     <%= link_to "Back to snippets", share_snippets_path %>

--- a/app/views/share/snippets/show.html.erb
+++ b/app/views/share/snippets/show.html.erb
@@ -11,7 +11,7 @@
 ) %>
 
 <%= render Pages::Header.new(title: "Snippet Share") %>
-<div class="section-content container py-gap">
+<div class="section-content container py-gap mb-3xl">
   <%= turbo_frame_tag :snippet_form, data: {turbo_action: "advance"} do %>
     <%= render CodeBlock::Snippet.new(@snippet) %>
   <% end %>

--- a/app/views/share/snippets/show.html.erb
+++ b/app/views/share/snippets/show.html.erb
@@ -13,12 +13,13 @@
 <%= render Pages::Header.new(title: "Snippet Share") %>
 <div class="section-content container py-gap mb-3xl">
   <%= turbo_frame_tag :snippet_form do %>
-    <%= render CodeBlock::Snippet.new(@snippet) %>
+    <div class="section-content">
+      <%= render CodeBlock::Snippet.new(@snippet) %>
+      <div>
+        <%= render Share::Snippets::Toolbar.new(@snippet, current_user: current_user) %>
+      </div>
+    </div>
   <% end %>
-
-  <div>
-    <%= render Share::Snippets::Toolbar.new(@snippet, current_user: current_user) %>
-  </div>
 
   <br>
 

--- a/app/views/share/snippets/toolbar.rb
+++ b/app/views/share/snippets/toolbar.rb
@@ -21,7 +21,7 @@ class Share::Snippets::Toolbar < ApplicationComponent
     if @snippet.screenshot.attached?
       new_share_snippet_tweet_path(@snippet, auto: "true")
     else
-      new_share_snippet_screenshot_path(@snippet)
+      new_share_snippet_screenshot_path(@snippet, auto: "true")
     end
   end
 end

--- a/app/views/share/snippets/toolbar.rb
+++ b/app/views/share/snippets/toolbar.rb
@@ -12,7 +12,9 @@ class Share::Snippets::Toolbar < ApplicationComponent
     flex_block do
       link_to "Share", share_url, class: "button primary"
       if @current_user&.can_edit?(@snippet)
-        link_to "Edit this snippet", edit_share_snippet_path(@snippet), class: "button secondary"
+        link_to "Edit this snippet", edit_share_snippet_path(@snippet),
+          class: "button secondary",
+          data: {turbo_frame: "snippet_form"}
       end
     end
   end

--- a/app/views/users/newsletter_subscriptions/banner.rb
+++ b/app/views/users/newsletter_subscriptions/banner.rb
@@ -4,7 +4,7 @@ class Users::NewsletterSubscriptions::Banner < ApplicationComponent
   include Phlex::Rails::Helpers::TurboFrameTag
 
   def view_template(&block)
-    div(class: "newsletter-banner section-content container py-gap lg:py-3xl lg:grid-cols-1/2") do
+    div(class: "newsletter-banner section-content container py-gap mb-3xl lg:py-3xl lg:grid-cols-1/2") do
       h3(class: "font-semibold") do
         plain "The Joy of Rails Newsletter: "
         span { "A spark of joy for your inbox" }

--- a/spec/requests/share/snippets_spec.rb
+++ b/spec/requests/share/snippets_spec.rb
@@ -104,6 +104,11 @@ RSpec.describe "/snippets", type: :request do
         post share_snippets_url, params: {snippet: {source: "puts \"Hello!\"", language: "ruby"}}
         expect(response).to redirect_to(edit_share_snippet_url(Snippet.last))
       end
+
+      it "redirects to the screenshot page" do
+        post share_snippets_url, params: {snippet: {source: "puts \"Hello!\"", language: "ruby"}, commit: "Share"}
+        expect(response).to redirect_to(new_share_snippet_screenshot_url(Snippet.last, auto: true))
+      end
     end
 
     context "with invalid parameters" do
@@ -158,6 +163,15 @@ RSpec.describe "/snippets", type: :request do
         patch share_snippet_url(snippet), params: {snippet: {source: "puts \"Goodbye!\""}}
         snippet.reload
         expect(response).to redirect_to(edit_share_snippet_url(snippet))
+      end
+
+      it "redirects to the screenshot page" do
+        user = login_as_user
+        Flipper.enable(:snippets, user)
+        snippet = FactoryBot.create(:snippet, author: user)
+        patch share_snippet_url(snippet), params: {snippet: {source: "puts \"Goodbye!\""}, commit: "Share"}
+        snippet.reload
+        expect(response).to redirect_to(new_share_snippet_screenshot_url(snippet, auto: true))
       end
     end
 

--- a/spec/requests/share/snippets_spec.rb
+++ b/spec/requests/share/snippets_spec.rb
@@ -109,6 +109,11 @@ RSpec.describe "/snippets", type: :request do
         post share_snippets_url, params: {snippet: {source: "puts \"Hello!\"", language: "ruby"}, commit: "Share"}
         expect(response).to redirect_to(new_share_snippet_screenshot_url(Snippet.last, auto: true))
       end
+
+      it "redirects to the show page" do
+        post share_snippets_url, params: {snippet: {source: "puts \"Hello!\"", language: "ruby"}, commit: "Save & Close"}
+        expect(response).to redirect_to(share_snippet_url(Snippet.last))
+      end
     end
 
     context "with invalid parameters" do
@@ -172,6 +177,15 @@ RSpec.describe "/snippets", type: :request do
         patch share_snippet_url(snippet), params: {snippet: {source: "puts \"Goodbye!\""}, commit: "Share"}
         snippet.reload
         expect(response).to redirect_to(new_share_snippet_screenshot_url(snippet, auto: true))
+      end
+
+      it "redirects to the show page" do
+        user = login_as_user
+        Flipper.enable(:snippets, user)
+        snippet = FactoryBot.create(:snippet, author: user)
+        patch share_snippet_url(snippet), params: {snippet: {source: "puts \"Goodbye!\""}, commit: "Save & Close"}
+        snippet.reload
+        expect(response).to redirect_to(share_snippet_url(snippet))
       end
     end
 

--- a/spec/system/snippets_spec.rb
+++ b/spec/system/snippets_spec.rb
@@ -54,12 +54,12 @@ RSpec.describe "Snippets", type: :system do
   end
 
   it "can share Snippet" do
-    snippet = FactoryBot.create(:snippet, author: login_as_user)
+    FactoryBot.create(:snippet, filename: "example.rb", author: login_as_user)
 
     visit share_snippets_path
 
     within("#snippets") do
-      expect(page).to have_content(snippet.filename)
+      expect(page).to have_content("example.rb")
       click_link "Share"
     end
 


### PR DESCRIPTION
Twitter (X) will crop the primary image for summary cards at a 2:1 aspect ratio. I can improve the appearance by modifying the code snippet screenshot to match those dimensions. I considered using ActiveStorage’s variants API to pad the uploads to the desired dimension on the server, but since the screenshot is coming from the frontend, I felt it would make more sense to use CSS to change the frontend appearance accordingly instead.

The key changes in CSS are to the snippet wrapper where we can use the `aspect-ratio: 2 / 1` to match the Twitter sizing up to a max. The `overflow-x: clip` property is useful to long lines while allowing the vertical content to remain visible ([this article has a good explainer](https://kilianvalkhof.com/2022/css-html/do-you-know-about-overflow-clip/)) You can clip in one direction while keeping your content visible in another direction.