### PR TITLE
Move wasm build to separate workflow on main

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,5 +1,3 @@
-# Put this in the file: .github/workflows/verify.yml
-
 name: Verify
 on: [push]
 
@@ -212,73 +210,3 @@ jobs:
           name: assets
           path: public
           retention-days: 1
-
-  wasm:
-    name: WebAssembly
-    needs: [test, lint, assets]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target: [web, node]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install build tools from apt
-        run: sudo apt-get install ruby bison make autoconf git curl build-essential libyaml-dev zlib1g-dev -y
-      - name: Install wasmtime
-        uses: bytecodealliance/actions/wasmtime/setup@v1
-      - name: Install brotli from apt
-        run: sudo apt-get install brotli -y
-      - name: Workaround for Debian ruby distribution
-        run: |
-          # avoid using system rubygems while installing docs
-          # related issue: https://github.com/rubygems/rubygems/issues/3831
-          sudo rm -rf /usr/lib/ruby/vendor_ruby/rubygems/defaults
-      - uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-      - name: Cache wasm
-        id: cache-wasm
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-wasm-${{ matrix.target }}
-        with:
-          path: |
-            build
-            rubies
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - uses: actions/download-artifact@v4
-        with:
-          name: assets
-          path: public
-      - run: ls -lahR public
-      - run: echo ${{ secrets.RAILS_MASTER_WASM_KEY }} > config/credentials/wasm.key
-      - run: mkdir -p .wasm
-      - name: Build rails wasm for web
-        run: TARGET=${{ matrix.target }} bin/wasm/build
-      - name: Pack rails wasm for web
-        run: TARGET=${{ matrix.target }} bin/wasm/pack
-      - name: Test rails wasm for node successful with wasmtime
-        run: |
-          if [[ "${{ matrix.target }}" == "node" ]]; then
-            bin/wasm/test-node
-          else
-            echo "Skipping test for wasm web"
-          fi
-      - name: Compress the wasm files
-        run: bin/wasm/compress
-      - run: ls -lahR public
-      - name: Upload wasm to cloud storage
-        run: |
-          if [[ "${{github.ref}}" == "refs/heads/main" ]]; then
-            RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_PRODUCTION_KEY }} \
-            RAILS_ENV=production \
-            bin/rails wasm:upload
-          else
-            RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_TEST_KEY }} \
-            RAILS_ENV=test \
-            bin/rails wasm:upload
-          fi

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,79 @@
+name: Wasm
+on:
+  workflow_run:
+    workflows:
+      - Deploy
+    branches:
+      - main
+    types:
+      - completed
+
+jobs:
+  wasm:
+    name: WebAssembly
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [web, node]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build tools from apt
+        run: sudo apt-get install ruby bison make autoconf git curl build-essential libyaml-dev zlib1g-dev -y
+      - name: Install wasmtime
+        uses: bytecodealliance/actions/wasmtime/setup@v1
+      - name: Install brotli from apt
+        run: sudo apt-get install brotli -y
+      - name: Workaround for Debian ruby distribution
+        run: |
+          # avoid using system rubygems while installing docs
+          # related issue: https://github.com/rubygems/rubygems/issues/3831
+          sudo rm -rf /usr/lib/ruby/vendor_ruby/rubygems/defaults
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Cache wasm
+        id: cache-wasm
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-wasm-${{ matrix.target }}
+        with:
+          path: |
+            build
+            rubies
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - uses: actions/download-artifact@v4
+        with:
+          name: assets
+          path: public
+      - run: ls -lahR public
+      - run: echo ${{ secrets.RAILS_MASTER_WASM_KEY }} > config/credentials/wasm.key
+      - run: mkdir -p .wasm
+      - name: Build rails wasm for web
+        run: TARGET=${{ matrix.target }} bin/wasm/build
+      - name: Pack rails wasm for web
+        run: TARGET=${{ matrix.target }} bin/wasm/pack
+      - name: Test rails wasm for node successful with wasmtime
+        run: |
+          if [[ "${{ matrix.target }}" == "node" ]]; then
+            bin/wasm/test-node
+          else
+            echo "Skipping test for wasm web"
+          fi
+      - name: Compress the wasm files
+        run: bin/wasm/compress
+      - run: ls -lahR public
+      - name: Upload wasm to cloud storage
+        run: |
+          if [[ "${{github.ref}}" == "refs/heads/main" ]]; then
+            RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_PRODUCTION_KEY }} \
+            RAILS_ENV=production \
+            bin/rails wasm:upload
+          else
+            RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_TEST_KEY }} \
+            RAILS_ENV=test \
+            bin/rails wasm:upload
+          fi


### PR DESCRIPTION
Building the WASM target for Joy of Rails was a fun project but I haven’t been able to invest the time needed to make it better. Frequent failures on the feature branches add friction. I’ve decided to remove WASM from the regular CI workflow. I’ll either decide to reinvest or remove WASM from Joy of Rails altogether in a future changeset.

<!-- Describe your changes and link to relevant issues or discussions. Please add motivation and context as needed. -->

## Pull request checklist

- [ ] I have written tests for code I have added or modified.
- [ ] I linted and tested the project with `bin/verify`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
