### PR TITLE
Add description to code snippets

### DIFF
--- a/app/controllers/share/snippets_controller.rb
+++ b/app/controllers/share/snippets_controller.rb
@@ -23,18 +23,18 @@ class Share::SnippetsController < ApplicationController
       source: "class User < ApplicationRecord\n\s\shas_many :posts\nend",
       language: "ruby"
     }
-    @snippet = current_user.snippets.new(snippet_params.presence || default_params)
+    @snippet = Current.user.snippets.new(snippet_params.presence || default_params)
   end
 
   # GET /snippets/1/edit
   def edit
-    @snippet = current_user.snippets.find(params[:id])
+    @snippet = Current.user.snippets.find(params[:id])
     @snippet.assign_attributes(snippet_params)
   end
 
   # POST /snippets
   def create
-    @snippet = current_user.snippets.new(snippet_params)
+    @snippet = Current.user.snippets.new(snippet_params)
 
     if @snippet.save
       redirect_to share_snippet_redirect_url(@snippet), notice: "Your snippet has been saved".emojoy, status: :see_other
@@ -45,7 +45,7 @@ class Share::SnippetsController < ApplicationController
 
   # PATCH/PUT /snippets/1
   def update
-    @snippet = current_user.snippets.find(params[:id])
+    @snippet = Current.user.snippets.find(params[:id])
     if @snippet.update(snippet_params)
       @snippet.attach_screenshot_from_base64(params[:screenshot]) if params[:screenshot]
 
@@ -57,7 +57,7 @@ class Share::SnippetsController < ApplicationController
 
   # DELETE /snippets/1
   def destroy
-    @snippet = current_user.snippets.find(params[:id])
+    @snippet = Current.user.snippets.find(params[:id])
     @snippet.destroy!
     redirect_to share_snippets_url, notice: "Your snippet has been deleted permanently".emojoy, status: :see_other
   end
@@ -77,7 +77,7 @@ class Share::SnippetsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def snippet_params
-    params.fetch(:snippet, {}).permit(:filename, :source, :language)
+    params.fetch(:snippet, {}).permit(:filename, :source, :language, :description)
   end
 
   def feature_enabled!

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -8,7 +8,7 @@ nav = {
 %>
 <article>
   <%= render Pages::Header.new(title: "Admin") %>
-  <div class="section-content container">
+  <div class="section-content container py-gap mb-3xl">
     <ul>
       <% nav.each do |label, url| %>
       <li>

--- a/app/views/components/code_block/container.rb
+++ b/app/views/components/code_block/container.rb
@@ -10,10 +10,6 @@ class CodeBlock::Container < ApplicationComponent
   end
 
   def view_template(&)
-    div(
-      class: class_names("code-wrapper", "highlight", "language-#{language}", *classes),
-      **options,
-      &
-    )
+    div(class: class_names("code-wrapper", "highlight", "language-#{language}", *classes), **options, &)
   end
 end

--- a/app/views/components/layouts/front_door_form.rb
+++ b/app/views/components/layouts/front_door_form.rb
@@ -30,11 +30,7 @@ class Layouts::FrontDoorForm < Phlex::HTML
   end
 
   def form_with(**, &)
-    super(
-      class: "grid grid-row-tight",
-      **,
-      &
-    )
+    super(class: "grid grid-row-tight", **, &)
   end
 
   def form_label(form, *args, **opts)

--- a/app/views/components/markdown/safe.rb
+++ b/app/views/components/markdown/safe.rb
@@ -1,0 +1,2 @@
+class Markdown::Safe < Markdown::Base
+end

--- a/app/views/share/snippet_tweets/tweet_button.rb
+++ b/app/views/share/snippet_tweets/tweet_button.rb
@@ -28,7 +28,7 @@ class Share::SnippetTweets::TweetButton < ApplicationComponent
   end
 
   def tweet_text
-    "Created with @joyofrails #{share_url}"
+    [@snippet.description.presence, "Created with @joyofrails #{share_url}"].compact.join("\n\n")
   end
 
   def encode(text)

--- a/app/views/share/snippets/form.rb
+++ b/app/views/share/snippets/form.rb
@@ -53,7 +53,15 @@ class Share::Snippets::Form < ApplicationComponent
         fieldset do
           flex_block do
             language_select(form, data: {action: "change->snippet-preview#preview"})
+          end
+        end
 
+        fieldset do
+          form.text_area :description, placeholder: "Say a few words about this code snippet", class: "w-full"
+        end
+
+        fieldset do
+          flex_block do
             plain form.submit "Share", class: "button primary"
 
             plain form.submit "Save", class: "button secondary"

--- a/app/views/share/snippets/index.html.erb
+++ b/app/views/share/snippets/index.html.erb
@@ -8,7 +8,8 @@
 
   <% @snippets.each do |snippet| %>
     <div id="<%= dom_id(snippet) %>" class="section-content mb-xl">
-      <%= link_to share_snippet_path(snippet), class: "block" do %>
+      <%= render Markdown::Safe.new(snippet.description) if snippet.description %>
+      <%= link_to share_snippet_path(snippet), class: "section-content" do %>
         <%= render CodeBlock::Snippet.new(snippet) %>
       <% end %>
       <div>

--- a/app/views/share/snippets/show.html.erb
+++ b/app/views/share/snippets/show.html.erb
@@ -14,6 +14,7 @@
 <div class="section-content container py-gap mb-3xl">
   <%= turbo_frame_tag :snippet_form do %>
     <div class="section-content">
+      <%= render Markdown::Safe.new(@snippet.description) if @snippet.description %>
       <%= render CodeBlock::Snippet.new(@snippet) %>
       <div>
         <%= render Share::Snippets::Toolbar.new(@snippet, current_user: current_user) %>

--- a/db/migrate/20240905104301_alter_snippets_change_url_to_description.rb
+++ b/db/migrate/20240905104301_alter_snippets_change_url_to_description.rb
@@ -1,0 +1,9 @@
+class AlterSnippetsChangeUrlToDescription < ActiveRecord::Migration[7.2]
+  def up
+    rename_column :snippets, :url, :description
+  end
+
+  def down
+    rename_column :snippets, :description, :url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_01_114558) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_05_104301) do
   create_table "_litestream_lock", id: false, force: :cascade do |t|
     t.integer "id"
   end
@@ -169,7 +169,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_01_114558) do
     t.text "source", null: false
     t.string "filename"
     t.string "language"
-    t.text "url"
+    t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "author_type", null: false

--- a/spec/factories/snippets.rb
+++ b/spec/factories/snippets.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     source { "puts \"Hello, world!\"" }
     language { "ruby" }
     filename { "example.rb" }
+    description { "# Hello World in Ruby" }
     author { build(:user) }
   end
 end

--- a/spec/requests/share/snippets_spec.rb
+++ b/spec/requests/share/snippets_spec.rb
@@ -87,8 +87,14 @@ RSpec.describe "/snippets", type: :request do
 
       it "creates a new Snippet" do
         expect {
-          post share_snippets_url, params: {snippet: {source: "puts \"Hello!\"", language: "ruby"}}
+          post share_snippets_url, params: {snippet: {source: "puts \"Hello!\"", language: "ruby", filename: "hello.rb", description: "A simple greeting"}}
         }.to change(Snippet, :count).by(1)
+
+        snippet = Snippet.last
+        expect(snippet.source).to eq("puts \"Hello!\"")
+        expect(snippet.language).to eq("ruby")
+        expect(snippet.filename).to eq("hello.rb")
+        expect(snippet.description).to eq("A simple greeting")
       end
 
       it "associates snippet with the current user" do

--- a/spec/requests/share/snippets_spec.rb
+++ b/spec/requests/share/snippets_spec.rb
@@ -8,6 +8,18 @@ RSpec.describe "/snippets", type: :request do
       expect(response).to be_successful
     end
 
+    it "renders a successful response without filename" do
+      FactoryBot.create(:snippet, filename: nil)
+      get share_snippets_url
+      expect(response).to be_successful
+    end
+
+    it "renders a successful response without description" do
+      FactoryBot.create(:snippet, description: nil)
+      get share_snippets_url
+      expect(response).to be_successful
+    end
+
     it "does not render the New Snippet button when not allowed" do
       get share_snippets_url
 
@@ -25,6 +37,18 @@ RSpec.describe "/snippets", type: :request do
   describe "GET /show" do
     it "renders a successful response" do
       snippet = FactoryBot.create(:snippet)
+      get share_snippet_url(snippet)
+      expect(response).to be_successful
+    end
+
+    it "renders a successful response without filename" do
+      snippet = FactoryBot.create(:snippet, filename: nil)
+      get share_snippet_url(snippet)
+      expect(response).to be_successful
+    end
+
+    it "renders a successful response without description" do
+      snippet = FactoryBot.create(:snippet, description: nil)
       get share_snippet_url(snippet)
       expect(response).to be_successful
     end


### PR DESCRIPTION
Now Snippets can be edited to have a description. Descriptions support markdown for rendering on the site. Description text is now added to prepopulated tweet text for sharing. 

In the future, we can add a markdown parser that can extract just the text for tweet sharing and for text search.