### PR TITLE
Phlex 2 upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,8 +37,8 @@ gem "sitepress-rails", group: [:default, :wasm] # Static site generator for Rail
 
 # gem "phlex-rails", group: [:default, :wasm] # An object-oriented alternative to ActionView for Ruby on Rails. [https://github.com/phlex-ruby/phlex-rails]
 # Phlex 2.0 upgrade
-gem "phlex-rails", git: "https://github.com/phlex-ruby/phlex-rails.git"
-gem "phlex", git: "https://github.com/phlex-ruby/phlex.git"
+gem "phlex-rails", "2.0.0.beta1"
+gem "phlex", "2.0.0.beta1"
 
 gem "commonmarker", require: false
 gem "invisible_captcha", group: [:default, :wasm] # Unobtrusive and flexible spam protection for Rails apps [https://github.com/markets/invisible_captcha]

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,12 @@ gem "image_processing", group: [:default, :wasm] # Use Active Storage variants [
 gem "inline_svg" # Embed SVGs in Rails views and style them with CSS [https://github.com/jamesmartin/inline_svg
 gem "rouge", group: [:default, :wasm] # Pure Ruby syntaix highlighter [https://github.com/rouge-ruby/rouge
 gem "sitepress-rails", group: [:default, :wasm] # Static site generator for Rails [https://sitepress.cc/getting-started/rails]
-gem "phlex-rails", group: [:default, :wasm] # An object-oriented alternative to ActionView for Ruby on Rails. [https://github.com/phlex-ruby/phlex-rails]
+
+# gem "phlex-rails", group: [:default, :wasm] # An object-oriented alternative to ActionView for Ruby on Rails. [https://github.com/phlex-ruby/phlex-rails]
+# Phlex 2.0 upgrade
+gem "phlex-rails", git: "https://github.com/phlex-ruby/phlex-rails.git"
+gem "phlex", git: "https://github.com/phlex-ruby/phlex.git"
+
 gem "commonmarker", require: false
 gem "invisible_captcha", group: [:default, :wasm] # Unobtrusive and flexible spam protection for Rails apps [https://github.com/markets/invisible_captcha]
 gem "color_conversion", group: [:default, :wasm] # A ruby gem to perform color conversions [https://github.com/devrieda/color_conversion]

--- a/Gemfile
+++ b/Gemfile
@@ -35,10 +35,8 @@ gem "inline_svg" # Embed SVGs in Rails views and style them with CSS [https://gi
 gem "rouge", group: [:default, :wasm] # Pure Ruby syntaix highlighter [https://github.com/rouge-ruby/rouge
 gem "sitepress-rails", group: [:default, :wasm] # Static site generator for Rails [https://sitepress.cc/getting-started/rails]
 
-# gem "phlex-rails", group: [:default, :wasm] # An object-oriented alternative to ActionView for Ruby on Rails. [https://github.com/phlex-ruby/phlex-rails]
-# Phlex 2.0 upgrade
-gem "phlex-rails", "2.0.0.beta1"
-gem "phlex", "2.0.0.beta1"
+gem "phlex", "2.0.0.beta1", group: [:default, :wasm] # An object-oriented view layer. [https://github.com/phlex-ruby/phlex]
+gem "phlex-rails", "2.0.0.beta1", group: [:default, :wasm] # Rails integration for Phlex [https://github.com/phlex-ruby/phlex-rails]
 
 gem "commonmarker", require: false
 gem "invisible_captcha", group: [:default, :wasm] # Unobtrusive and flexible spam protection for Rails apps [https://github.com/markets/invisible_captcha]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,3 @@
-GIT
-  remote: https://github.com/phlex-ruby/phlex-rails.git
-  revision: 8e353bc95f2512ee12706f05bde3994cbc62db50
-  specs:
-    phlex-rails (2.0.0)
-      phlex (~> 2.0.0)
-      railties (>= 6.1, < 8)
-
-GIT
-  remote: https://github.com/phlex-ruby/phlex.git
-  revision: 815c94ea7d04abca03d925b730bd0ae41fc234b4
-  specs:
-    phlex (2.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -340,6 +326,10 @@ GEM
     parser (3.3.4.0)
       ast (~> 2.4.1)
       racc
+    phlex (2.0.0.beta1)
+    phlex-rails (2.0.0.beta1)
+      phlex (= 2.0.0.beta1)
+      railties (>= 6.1, < 8)
     postmark (1.25.1)
       json
     postmark-rails (0.22.1)
@@ -616,8 +606,8 @@ DEPENDENCIES
   litestream
   meta-tags
   mission_control-jobs
-  phlex!
-  phlex-rails!
+  phlex (= 2.0.0.beta1)
+  phlex-rails (= 2.0.0.beta1)
   postmark-rails
   propshaft
   puma (>= 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/phlex-ruby/phlex-rails.git
-  revision: 14d393f64e12b9a602d0677cdca01e4f84d215cd
+  revision: 8e353bc95f2512ee12706f05bde3994cbc62db50
   specs:
     phlex-rails (2.0.0)
       phlex (~> 2.0.0)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/phlex-ruby/phlex.git
-  revision: 74066734f91db0e82605f409700a0afe729334a5
+  revision: 815c94ea7d04abca03d925b730bd0ae41fc234b4
   specs:
     phlex (2.0.0)
 
@@ -419,7 +419,7 @@ GEM
       rainbow (>= 2.0, < 4.0)
       rexml (~> 3.1)
     regexp_parser (2.9.2)
-    reline (0.5.9)
+    reline (0.5.10)
       io-console (~> 0.5)
     require_all (3.0.0)
     rexml (3.3.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,17 @@
+GIT
+  remote: https://github.com/phlex-ruby/phlex-rails.git
+  revision: 14d393f64e12b9a602d0677cdca01e4f84d215cd
+  specs:
+    phlex-rails (2.0.0)
+      phlex (~> 2.0.0)
+      railties (>= 6.1, < 8)
+
+GIT
+  remote: https://github.com/phlex-ruby/phlex.git
+  revision: 74066734f91db0e82605f409700a0afe729334a5
+  specs:
+    phlex (2.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -326,10 +340,6 @@ GEM
     parser (3.3.4.0)
       ast (~> 2.4.1)
       racc
-    phlex (1.10.3)
-    phlex-rails (1.2.1)
-      phlex (~> 1.10.0)
-      railties (>= 6.1, < 8)
     postmark (1.25.1)
       json
     postmark-rails (0.22.1)
@@ -606,7 +616,8 @@ DEPENDENCIES
   litestream
   meta-tags
   mission_control-jobs
-  phlex-rails
+  phlex!
+  phlex-rails!
   postmark-rails
   propshaft
   puma (>= 5.0)

--- a/app/views/components/clipboard_copy.rb
+++ b/app/views/components/clipboard_copy.rb
@@ -28,11 +28,11 @@ class ClipboardCopy < Phlex::HTML
             "absolute hidden text-xs md:text-base top-0 md:top-[3px] left-[-68px] md:left-[-72px] group-focus:inline py-1 px-2 text-white font-semibold bg-black rounded-m"
         ) { "Copied!" }
         whitespace
-        plain inline_svg_tag "copy-text.svg",
+        raw inline_svg_tag "copy-text.svg",
           class:
             "copy-text inline-block cursor-pointer fill-current group-focus:hidden w-[16px] md:w-[20px]"
         whitespace
-        plain inline_svg_tag "check-mark.svg",
+        raw inline_svg_tag "check-mark.svg",
           class:
             "check-mark hidden fill-green-600 group-focus:inline-block w-[16px] md:w-[20px]"
         whitespace

--- a/app/views/components/clipboard_copy.rb
+++ b/app/views/components/clipboard_copy.rb
@@ -20,7 +20,7 @@ class ClipboardCopy < Phlex::HTML
           "button--clipboard-copy text-gray-500 dark:text-gray-400 group rounded-md text-sm md:p-2 relative",
         data_action: "clipboard-copy#copy",
         data_clipboard_copy_target: "source",
-        data_value: text
+        data_value: ERB::Util.html_escape(text)
       ) do
         whitespace
         span(

--- a/app/views/components/clipboard_copy.rb
+++ b/app/views/components/clipboard_copy.rb
@@ -1,5 +1,5 @@
 class ClipboardCopy < Phlex::HTML
-  include InlineSvg::ActionView::Helpers
+  include PhlexConcerns::SvgTag
 
   attr_accessor :text
 
@@ -28,11 +28,11 @@ class ClipboardCopy < Phlex::HTML
             "absolute hidden text-xs md:text-base top-0 md:top-[3px] left-[-68px] md:left-[-72px] group-focus:inline py-1 px-2 text-white font-semibold bg-black rounded-m"
         ) { "Copied!" }
         whitespace
-        raw inline_svg_tag "copy-text.svg",
+        svg_tag "copy-text.svg",
           class:
             "copy-text inline-block cursor-pointer fill-current group-focus:hidden w-[16px] md:w-[20px]"
         whitespace
-        raw inline_svg_tag "check-mark.svg",
+        svg_tag "check-mark.svg",
           class:
             "check-mark hidden fill-green-600 group-focus:inline-block w-[16px] md:w-[20px]"
         whitespace

--- a/app/views/components/code_block/app_file_header.rb
+++ b/app/views/components/code_block/app_file_header.rb
@@ -11,7 +11,7 @@ class CodeBlock::AppFileHeader < ApplicationComponent
     render CodeBlock::Header.new do
       link(app_file.repo_url, "Source code on Github", class: "nc") do
         plain app_file.app_path.to_s
-        plain inline_svg_tag("external-link.svg", class: "icon icon-sm", height: 12, width: 12)
+        raw inline_svg_tag("external-link.svg", class: "icon icon-sm", height: 12, width: 12)
       end
     end
   end

--- a/app/views/components/code_block/app_file_header.rb
+++ b/app/views/components/code_block/app_file_header.rb
@@ -1,5 +1,5 @@
 class CodeBlock::AppFileHeader < ApplicationComponent
-  include InlineSvg::ActionView::Helpers
+  include PhlexConcerns::SvgTag
 
   attr_reader :app_file
 
@@ -11,7 +11,7 @@ class CodeBlock::AppFileHeader < ApplicationComponent
     render CodeBlock::Header.new do
       link(app_file.repo_url, "Source code on Github", class: "nc") do
         plain app_file.app_path.to_s
-        raw inline_svg_tag("external-link.svg", class: "icon icon-sm", height: 12, width: 12)
+        svg_tag("external-link.svg", class: "icon icon-sm", height: 12, width: 12)
       end
     end
   end

--- a/app/views/components/code_block/code.rb
+++ b/app/views/components/code_block/code.rb
@@ -19,7 +19,7 @@ class CodeBlock::Code < ApplicationComponent
   def view_template(&block)
     pre data: data do
       code do
-        unsafe_raw code_formatter.format(lexer.lex(source))
+        safe code_formatter.format(lexer.lex(source))
       end
     end
   end

--- a/app/views/components/code_block/header.rb
+++ b/app/views/components/code_block/header.rb
@@ -3,7 +3,7 @@ class CodeBlock::Header < ApplicationComponent
 
   def view_template(&)
     div(class: "code-header") do
-      plain inline_svg_tag("app-dots.svg", class: "app-dots")
+      raw inline_svg_tag("app-dots.svg", class: "app-dots")
       span(class: "code-title", &)
     end
   end

--- a/app/views/components/code_block/header.rb
+++ b/app/views/components/code_block/header.rb
@@ -1,9 +1,9 @@
 class CodeBlock::Header < ApplicationComponent
-  include InlineSvg::ActionView::Helpers
+  include PhlexConcerns::SvgTag
 
   def view_template(&)
     div(class: "code-header") do
-      raw inline_svg_tag("app-dots.svg", class: "app-dots")
+      svg_tag("app-dots.svg", class: "app-dots")
       span(class: "code-title", &)
     end
   end

--- a/app/views/components/color_schemes/css.rb
+++ b/app/views/components/color_schemes/css.rb
@@ -9,9 +9,9 @@ class ColorSchemes::Css < Phlex::HTML
   end
 
   def view_template
-    plain css_variables
+    raw safe(css_variables)
     if my_theme?
-      plain my_css_variables
+      raw safe(my_css_variables)
     end
   end
 

--- a/app/views/components/layouts/front_door_form.rb
+++ b/app/views/components/layouts/front_door_form.rb
@@ -4,7 +4,7 @@ class Layouts::FrontDoorForm < Phlex::HTML
   include Phlex::Rails::Helpers::Label
   include Phlex::Rails::Helpers::Object
   include Phlex::Rails::Helpers::Routes
-  include InlineSvg::ActionView::Helpers
+  include PhlexConcerns::SvgTag
 
   def initialize(title:)
     @title = title
@@ -17,7 +17,7 @@ class Layouts::FrontDoorForm < Phlex::HTML
   def form_layout(&block)
     div(class: "flex min-h-full flex-col justify-center container py-xl lg:px-3xl") do
       div(class: "mx-auto w-full max-w-sm text-theme") do
-        raw inline_svg_tag "joy-logo.svg",
+        svg_tag "joy-logo.svg",
           class: "fill-current mx-auto",
           style: "max-width: 64px;",
           alt: "Joy of Rails"

--- a/app/views/components/layouts/front_door_form.rb
+++ b/app/views/components/layouts/front_door_form.rb
@@ -35,13 +35,13 @@ class Layouts::FrontDoorForm < Phlex::HTML
 
   def form_label(form, *args, **opts)
     div(class: "flex items-center justify-between") do
-      plain form.label(*args, class: "block text-sm font-medium leading-6", **opts)
+      form.label(*args, class: "block text-sm font-medium leading-6", **opts)
     end
   end
 
   def form_field(form, method, *args, **opts)
     div(class: "mt-2") do
-      plain form.send(
+      form.send(
         method,
         *args,
         class: "block w-full rounded-md py-1.5 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6",
@@ -52,7 +52,7 @@ class Layouts::FrontDoorForm < Phlex::HTML
 
   def form_button(form, text)
     div(class: "pt-6") do
-      plain form.button text,
+      form.button text,
         type: :submit,
         class:
           "flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"

--- a/app/views/components/layouts/front_door_form.rb
+++ b/app/views/components/layouts/front_door_form.rb
@@ -17,7 +17,7 @@ class Layouts::FrontDoorForm < Phlex::HTML
   def form_layout(&block)
     div(class: "flex min-h-full flex-col justify-center container py-xl lg:px-3xl") do
       div(class: "mx-auto w-full max-w-sm text-theme") do
-        plain inline_svg_tag "joy-logo.svg",
+        raw inline_svg_tag "joy-logo.svg",
           class: "fill-current mx-auto",
           style: "max-width: 64px;",
           alt: "Joy of Rails"

--- a/app/views/components/markdown/allows_erb.rb
+++ b/app/views/components/markdown/allows_erb.rb
@@ -21,7 +21,7 @@ module Markdown::AllowsErb
       end
     in :text
       if node.string_content.match?(ERB_TAGS)
-        unsafe_raw(node.string_content)
+        raw safe(node.string_content)
       else
         super
       end

--- a/app/views/components/markdown/application.rb
+++ b/app/views/components/markdown/application.rb
@@ -24,10 +24,10 @@ class Markdown::Application < Markdown::Base
   end
 
   def html_block(html)
-    unsafe_raw(html)
+    raw safe(html)
   end
 
   def html_inline(html)
-    unsafe_raw(html)
+    raw safe(html)
   end
 end

--- a/app/views/components/markdown/article.rb
+++ b/app/views/components/markdown/article.rb
@@ -48,7 +48,7 @@ class Markdown::Article < Markdown::Application
   end
 
   def anchor_svg
-    unsafe_raw(<<-SVG)
+    raw safe(<<-SVG)
       <svg version="1.1" aria-hidden="true" stroke="currentColor" viewBox="0 0 16 16" width="28" height="28">
         <path d="M4 9h1v1h-1c-1.5 0-3-1.69-3-3.5s1.55-3.5 3-3.5h4c1.45 0 3 1.69 3 3.5 0 1.41-0.91 2.72-2 3.25v-1.16c0.58-0.45 1-1.27 1-2.09 0-1.28-1.02-2.5-2-2.5H4c-0.98 0-2 1.22-2 2.5s1 2.5 2 2.5z m9-3h-1v1h1c1 0 2 1.22 2 2.5s-1.02 2.5-2 2.5H9c-0.98 0-2-1.22-2-2.5 0-0.83 0.42-1.64 1-2.09v-1.16c-1.09 0.53-2 1.84-2 3.25 0 1.81 1.55 3.5 3 3.5h4c1.45 0 3-1.69 3-3.5s-1.5-3.5-3-3.5z"></path>
       </svg>

--- a/app/views/components/phlex_concerns/svg_tag.rb
+++ b/app/views/components/phlex_concerns/svg_tag.rb
@@ -1,0 +1,11 @@
+module PhlexConcerns::SvgTag
+  extend ActiveSupport::Concern
+
+  included do
+    include InlineSvg::ActionView::Helpers
+  end
+
+  def svg_tag(*, **)
+    raw inline_svg_tag(*, **)
+  end
+end

--- a/app/views/components/pwa/web_push_demo.rb
+++ b/app/views/components/pwa/web_push_demo.rb
@@ -29,7 +29,7 @@ class Pwa::WebPushDemo < Phlex::HTML
         data: {
           "pwa-web-push-demo-target": "sendDemoPushForm"
         } do |f|
-        plain f.hidden_field :subscription,
+        f.hidden_field :subscription,
           data: {
             "pwa-web-push-demo-target": "subscriptionField"
           }
@@ -41,8 +41,8 @@ class Pwa::WebPushDemo < Phlex::HTML
           class: "flex flex-wrap gap-2",
           disabled: true
         ) do
-          plain f.text_field :title, value: "Joy of Rails"
-          plain f.text_field :message, value: "Hello World"
+          f.text_field :title, value: "Joy of Rails"
+          f.text_field :message, value: "Hello World"
           button(class: "button primary") do
             "Send push notification to myself"
           end

--- a/app/views/settings/color_schemes/show_view.rb
+++ b/app/views/settings/color_schemes/show_view.rb
@@ -152,7 +152,7 @@ class Settings::ColorSchemes::ShowView < ApplicationView
       "You can toggle the dark mode switch to see how the color scheme looks in light or dark mode. Choosing **Light Mode** or **Dark Mode** will save in your browser local storage and will persist across page views on your current device. Choose **System Mode** to remove the saved choice and fall back to your system preference."
     end
     div(class: "outside") do
-      render "darkmode/switch", enable_description: true, enable_outline: true
+      render partial: "darkmode/switch", enable_description: true, enable_outline: true
     end
   end
 

--- a/app/views/settings/syntax_highlights/form.rb
+++ b/app/views/settings/syntax_highlights/form.rb
@@ -78,7 +78,7 @@ class Settings::SyntaxHighlights::Form < ApplicationView
       "Toggle this switch to see the syntax highlighting when the _site_ is Light or Dark Mode. Choosing **Light Mode** or **Dark Mode** will save in your browser local storage and will persist across page views on your current device. Choose **System Mode** to remove the saved choice and fall back to your system preference."
     end
     div(class: "outside") do
-      render "darkmode/switch", enable_description: true, enable_outline: true
+      render partial: "darkmode/switch", enable_description: true, enable_outline: true
     end
   end
 

--- a/app/views/share/snippet_screenshots/form.rb
+++ b/app/views/share/snippet_screenshots/form.rb
@@ -27,7 +27,7 @@ class Share::SnippetScreenshots::Form < ApplicationComponent
       render CodeBlock::Snippet.new(snippet, screenshot: true, data: {snippet_screenshot_target: "snippet"})
 
       fieldset do
-        plain form.button "Share",
+        form.button "Share",
           class: "button primary",
           data: {snippet_screenshot_target: "submitButton"}
       end

--- a/app/views/share/snippets/form.rb
+++ b/app/views/share/snippets/form.rb
@@ -62,13 +62,13 @@ class Share::Snippets::Form < ApplicationComponent
 
         fieldset do
           flex_block do
-            plain form.submit "Share", class: "button primary"
+            form.submit "Share", class: "button primary"
 
-            plain form.submit "Save", class: "button secondary"
+            form.submit "Save", class: "button secondary"
 
-            plain form.submit "Save & Close", class: "button secondary"
+            form.submit "Save & Close", class: "button secondary"
 
-            plain form.submit "Preview",
+            form.submit "Preview",
               class: "button secondary hidden",
               formaction: form_path,
               formmethod: "get",
@@ -125,8 +125,8 @@ class Share::Snippets::Form < ApplicationComponent
   def language_select(form, data: {})
     div(class: "flex items-start flex-col space-col-4 md:items-center md:flex-row md:space-row-4") do
       fieldset do
-        plain form.label :language, class: "sr-only"
-        plain form.select :language,
+        form.label :language, class: "sr-only"
+        form.select :language,
           language_select_options,
           {},
           data:,

--- a/app/views/users/magic_session_tokens/new_view.rb
+++ b/app/views/users/magic_session_tokens/new_view.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class Users::MagicSessionTokens::NewView < ApplicationView
-  # include Phlex::Rails::Helpers::FormWith
-  # include Phlex::Rails::Helpers::Object
-  # include Phlex::Rails::Helpers::Routes
-  # include InlineSvg::ActionView::Helpers
-
   def initialize(user:)
     @user = user
   end

--- a/app/views/users/newsletter_subscriptions/form.rb
+++ b/app/views/users/newsletter_subscriptions/form.rb
@@ -16,7 +16,7 @@ class Users::NewsletterSubscriptions::Form < ApplicationComponent
       div(class: "flex flex-row items-center mt-2") do
         div(class: "flex-grow mr-2") do
           whitespace
-          plain f.email_field :email,
+          f.email_field :email,
             type: :email,
             autocomplete: "off",
             placeholder: "your@joymail.com",
@@ -24,7 +24,7 @@ class Users::NewsletterSubscriptions::Form < ApplicationComponent
               "flex-1 rounded bg-white/5 focus-ring focus:ring-0 ring-1 ring-inset ring-white/10 w-full lg:min-w-[36ch] "
         end
         div do
-          plain f.submit "Subscribe", class: "button primary focus-ring"
+          f.submit "Subscribe", class: "button primary focus-ring"
         end
       end
 

--- a/app/views/users/newsletter_subscriptions/show_view.rb
+++ b/app/views/users/newsletter_subscriptions/show_view.rb
@@ -29,7 +29,7 @@ class Users::NewsletterSubscriptions::ShowView < ApplicationView
         end
 
         script(type: "text/javascript") do
-          unsafe_raw <<~JS
+          raw safe(<<~JS)
             if (window.plausible) {
               window.plausible("Newsletter signup");
               console.log("Newsletter signup");

--- a/app/views/users/passwords/new_view.rb
+++ b/app/views/users/passwords/new_view.rb
@@ -4,7 +4,6 @@ class Users::Passwords::NewView < ApplicationView
   include Phlex::Rails::Helpers::FormWith
   include Phlex::Rails::Helpers::Object
   include Phlex::Rails::Helpers::Routes
-  include InlineSvg::ActionView::Helpers
 
   def initialize(user:)
     @user = user

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,7 +11,6 @@ require_relative "../config/environment"
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
-require "phlex/testing/view_helper"
 require "w3c_validators"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/views/components/clipboard_copy_spec.rb
+++ b/spec/views/components/clipboard_copy_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe ClipboardCopy, type: :view do
+  def render(text, &block)
+    Capybara.string(described_class.new(text:).call)
+  end
+
+  it "renders the clipboard copy button" do
+    expect(render("Hello")).to have_css("button", text: "Copied!")
+  end
+
+  it "gracefully handles text containing ERB when processed by ERB" do
+    text = "<%= \"color\" %>"
+    rendered = described_class.new(text:).call
+    processed = ERB.new(rendered).result(binding)
+
+    expect(Capybara.string(processed)).to have_css("[data-value*=color]")
+  end
+end

--- a/spec/views/components/markdown/erb_spec.rb
+++ b/spec/views/components/markdown/erb_spec.rb
@@ -77,5 +77,26 @@ RSpec.describe "Markdown with Erb", type: :view do
       HTML
       expect(render(md)).to eq(html)
     end
+
+    it "handles fenced erb with text" do
+      md = <<~'MD'
+        ```erb
+        <%
+        color_name = @color_scheme.name.parameterize
+        # #to_hsla defined as a helper method
+        %>
+        <style>
+        :root {
+        <%= @color_scheme.weights.map { |weight, color| "--color-#{color_name}-#{weight}: #{to_hsla(color)};" }.join("\n\s\s") %>
+        <% if @my_theme %>
+        <%= @color_scheme.weights.map { |weight, color| "--my-color-#{weight}: var(--color-#{color_name}-#{weight});" }.join("\n\s\s") %>
+        <% end %>
+        }
+        </style>
+        ```
+      MD
+
+      expect(md).to include("color_name = @color_scheme.name.parameterize")
+    end
   end
 end


### PR DESCRIPTION
Phlex 2.0 is currently in beta, soon to be released.

This PR upgrades existing components to new APIs and usage. Here‘s a summary of what‘s changed:

* `unsafe_raw` has been removed in Phlex 2. Most usage is in the Phlex-based Markdown components for converting admin-authored markdown to html. Usage is now `raw safe(content)`.
* I had been using `plain` in a number of contexts that no longer appear to be valid. As a wrapper for Rails form helpers, I was able to simply remove use of `plain`. For integration with the `inline_svg` gem, use of `plain` is now replaced with `raw`. I believe the `inline_svg` method already returns `SafeBuffer` strings, so no need to mark them as `safe`.
* I needed to specify `:partial` for rendering the darkmode ERB partial from Phlex, i.e., `render partial: "darkmode/switch"`.
* I had to remove `require "phlex/testing/view_helper"` from spec helper. Not entirely sure whether I was using this in the first place but it didn‘t appear than my existing Phlex component specs need to change as a result.
* The _most interesting_ change I had to make was [here](https://github.com/joyofrails/joyofrails.com/compare/chore/phlex-2-upgrade?expand=1#diff-0cf9cbb792b06e73377694bb2362d9c71cc4523750727778c935ad47a6b67925R23), to wrap the ClipboardCopy source value with `ERB::Util.html_escape`. It appears that Phlex now treats html attributes (or just `data` attributes?) with string safety which, in this case, was causing a syntax error when trying to render articles with code blocks that contained HTML and strings in the rendered code source. The syntax error occurs when there is escaped ERB in the source code that we are passing to the data attribute and due to the fact that the markdown content is secondarily processed by ERB for my custom handling of `*.mdrb` files. I was able to minimally reproduce the issue in [this spec](https://github.com/joyofrails/joyofrails.com/pull/214/files#diff-9b57eb6cd0c995f73b58b8dcb4c3a81dc64f150438123fac109571d9a568931b). The tricky part was that Rails ActionView was raising a `SyntaxError` on a large document but I wasn’t able pinpoint the origin of the error until I whittled it down to the spec linked here.