### PR TITLE
Update home screen article

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,7 +343,7 @@ GEM
     psych (5.1.2)
       stringio
     public_suffix (6.0.0)
-    puma (6.4.2)
+    puma (6.4.3)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -644,4 +644,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.5.6
+   2.5.19

--- a/app/content/pages/articles/add-your-rails-app-to-the-home-screen.html.mdrb
+++ b/app/content/pages/articles/add-your-rails-app-to-the-home-screen.html.mdrb
@@ -440,9 +440,7 @@ As a review, here’s the current `manifest.json.erb` for Joy of Rails:
 
 And here‘s the rendered result your browser sees right now:
 
-<div class="window">
-<%= tag.iframe src: pwa_manifest_path(format: :json) %>
-</div>
+<%= render CodeBlock::Article.new(ApplicationController.render("pwa/manifest", assigns: { color_scheme: ColorScheme.cached_default }), language: "erb") %>
 
 You‘ll see there‘s a few properties in the Joy of Rails manifest that we didn‘t cover in this article—the [MDN guide on web app manifests](https://developer.mozilla.org/en-US/docs/Web/Manifest) serves as a good reference to learn more.
 

--- a/app/content/pages/articles/add-your-rails-app-to-the-home-screen.html.mdrb
+++ b/app/content/pages/articles/add-your-rails-app-to-the-home-screen.html.mdrb
@@ -2,8 +2,8 @@
 title: Add your Rails app to the Home Screen - the Ultimate Guide
 author: Ross Kaffenberger
 layout: article
-summary: Rails 8 will support Progressive Web Apps (PWA) out-of-the-box but you have all the tools you need to make your app installable today
-description: Rails 8 will support Progressive Web Apps (PWA) out-of-the-box but you have all the tools you need to make your Rails app installable today
+summary: Rails 8 will support Progressive Web Apps (PWA) out-of-the-box but you have all the tools you need to make your app installable today.
+description: Rails 8 will support Progressive Web Apps (PWA) out-of-the-box but you have all the tools you need to make your Rails app installable today.
 published: '2024-09-20'
 uuid: f17af1f0-5840-46f3-9b3e-33bdceb3cb93
 image: articles/add-your-rails-app-to-the-home-screen/ruby-app-icon.jpg

--- a/app/controllers/pwa/installation_instructions_controller.rb
+++ b/app/controllers/pwa/installation_instructions_controller.rb
@@ -3,6 +3,7 @@ class Pwa::InstallationInstructionsController < ApplicationController
     @installation_instructions = if params[:user_agent_nickname]
       Pwa::NamedInstallationInstructions.find(params[:user_agent_nickname])
     else
+      Honeybadger.event("installation_instructions_controller.show", user_agent: request.user_agent)
       Pwa::UserAgentInstallationInstructions.new(request.user_agent)
     end
   end

--- a/app/models/pwa/named_installation_instructions.rb
+++ b/app/models/pwa/named_installation_instructions.rb
@@ -24,6 +24,8 @@ module Pwa
       case os_name
       when /macos/i
         "macOS"
+      when /ipad/i
+        "iPad"
       when /ios/i
         "iOS"
       else


### PR DESCRIPTION
A reader on Reddit reported that visiting the article triggered a download of the the manifest.json file. I was able to reproduce in Firefox on macOS desktop. The culprit was rendering the manifest.json file in an iframe. I changed it so that the rendered manifest is now rendered inline in a codeblock instead.

Also updated some copy.

<!-- Describe your changes and link to relevant issues or discussions. Please add motivation and context as needed. -->

## Pull request checklist

- [ ] I have written tests for code I have added or modified.
- [x] I linted and tested the project with `bin/verify`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
