### PR TITLE
Fixes for PWA install instructions

### DIFF
--- a/app/models/pwa/named_installation_instructions.rb
+++ b/app/models/pwa/named_installation_instructions.rb
@@ -20,23 +20,6 @@ module Pwa
       new(user_agent_nickname)
     end
 
-    def self.os_title(os_name)
-      case os_name
-      when /macos/i
-        "macOS"
-      when /ipad/i
-        "iPad"
-      when /ios/i
-        "iOS"
-      else
-        os_name&.titleize || "this platform"
-      end
-    end
-
-    def self.browser_title(browser_name)
-      browser_name&.titleize || "your browser"
-    end
-
     attr_reader :user_agent_nickname
 
     def initialize(user_agent_nickname)
@@ -50,41 +33,35 @@ module Pwa
     def os_name
       case user_agent_nickname
       when /macos/i
-        "macos"
+        "macOS"
+      when /ipados/i
+        "iPadOS"
       when /windows/i
-        "windows"
+        "Windows"
       when /ios/i
-        "ios"
+        "iOS"
       when /android/i
-        "android"
+        "Android"
       when /linux/i
-        "linux"
+        "Linux"
       else
         "your platform"
       end
     end
 
-    def os_title
-      self.class.os_title(os_name)
-    end
-
     def browser_name
       case user_agent_nickname
       when /chrome/i
-        "chrome"
+        "Chrome"
       when /firefox/i
-        "firefox"
+        "Firefox"
       when /edge/i
-        "edge"
+        "Microsoft Edge"
       when /safari/i
-        "safari"
+        "Safari"
       else
         "this browser"
       end
-    end
-
-    def browser_title
-      self.class.browser_title(browser_name)
     end
 
     def full_version

--- a/app/models/pwa/user_agent_installation_instructions.rb
+++ b/app/models/pwa/user_agent_installation_instructions.rb
@@ -25,16 +25,8 @@ module Pwa
       @device_detector.os_name
     end
 
-    def os_title
-      Pwa::NamedInstallationInstructions.os_title(os_name)
-    end
-
     def browser_name
       @device_detector.name
-    end
-
-    def browser_title
-      Pwa::NamedInstallationInstructions.browser_title(browser_name)
     end
 
     private
@@ -43,6 +35,8 @@ module Pwa
       case os_name
       when /ios/i
         "ios"
+      when /ipad/i
+        "ipados"
       when /android/i
         "android"
       when /mac/i
@@ -60,7 +54,7 @@ module Pwa
         "chrome"
       when /firefox|fxios/i
         "firefox"
-      when /edg/i
+      when /edge/i
         "edge"
       when /safari/i
         "safari"

--- a/app/views/pwa/installation_instructions/_installation_instructions.html.erb
+++ b/app/views/pwa/installation_instructions/_installation_instructions.html.erb
@@ -1,11 +1,11 @@
 <div class="section-content">
   <h3 class="font-semibold mb-2" style="margin-top: 0;">
-    How to Install a Progressive Web App from <%= installation_instructions.browser_title %> for <%= installation_instructions.os_title %>
+    How to Install a Progressive Web App from <%= installation_instructions.browser_name&.titleize %> for <%= installation_instructions.os_name %>
   </h3>
   <%= begin
     render @installation_instructions.partial_name, installation_instructions: installation_instructions
   rescue ArgumentError
-    Honeybadger.notify("Unsupported PWA installation instructions for #{installation_instructions.os_title} on #{installation_instructions.browser_title}")
+    Honeybadger.notify("Unsupported PWA installation instructions for #{installation_instructions.os_name} on #{installation_instructions.browser_name}")
     render "unsupported", installation_instructions: installation_instructions
   end %>
 

--- a/app/views/pwa/installation_instructions/_unsupported.html.erb
+++ b/app/views/pwa/installation_instructions/_unsupported.html.erb
@@ -1,5 +1,5 @@
 <p>We don't currently have install instructions for
-  <%= installation_instructions.browser_title || "this browser" %>
+  <%= installation_instructions.browser_name || "this browser" %>
   on
-  <%= installation_instructions.os_title || "your platform" %>.
+  <%= installation_instructions.os_name || "your platform" %>.
 </p>

--- a/app/views/pwa/installation_instructions/select.rb
+++ b/app/views/pwa/installation_instructions/select.rb
@@ -26,7 +26,16 @@ class Pwa::InstallationInstructions::Select < ApplicationComponent
 
   def select_options
     Pwa::NamedInstallationInstructions.user_agent_nicknames.map do |partial_name|
-      [partial_name.titleize, partial_name]
+      [titleize(partial_name), partial_name]
     end
+  end
+
+  def titleize(partial_name)
+    partial_name
+      .tr("_", " ")
+      .gsub(/(?:\A|\s)\w/) { |match| match.upcase }
+      .gsub(/macos/i, "macOS")
+      .gsub(/ios/i, "iOS")
+      .gsub(/ipad/i, "iPad")
   end
 end

--- a/app/views/pwa/installation_instructions/user_agents/_ios_chrome.html.erb
+++ b/app/views/pwa/installation_instructions/user_agents/_ios_chrome.html.erb
@@ -1,3 +1,5 @@
+<p>To add this web app to your home screen on <%= @installation_instructions.os_name %>:</p>
+
 <ol>
   <li>Tap the <strong>Share</strong> button at the bottom of the screen.</li>
   <li>Scroll down and tap on <strong>Add to Home Screen</strong>.</li>

--- a/app/views/pwa/installation_instructions/user_agents/_ios_edge.html.erb
+++ b/app/views/pwa/installation_instructions/user_agents/_ios_edge.html.erb
@@ -1,4 +1,4 @@
-<p>To add this web app to your home screen from Microsoft Edge on iOS:</p>
+<p>To add this web app to your home screen from Microsoft Edge on <%= @installation_instructions.os_name %>:</p>
 <ol>
   <li>Tap the <strong>Share</strong> button at the bottom of the screen.</li>
   <li>Scroll down and tap <strong>Add to Home Screen</strong>.</li>

--- a/app/views/pwa/installation_instructions/user_agents/_ios_firefox.html.erb
+++ b/app/views/pwa/installation_instructions/user_agents/_ios_firefox.html.erb
@@ -1,6 +1,6 @@
-<p>To add this web app to your home screen on iOS:</p>
+<p>To add this web app to your home screen on <%= @installation_instructions.os_name %>:</p>
 <ol>
-  <li>Tap the <strong>Share</strong> button at the bottom of the screen.</li>
+  <li>Tap the <strong>Share</strong> button.</li>
   <li>Scroll down and tap on <strong>Add to Home Screen</strong>.</li>
   <li>Customize the name of the app (optional) and tap <strong>Add</strong>.</li>
   <li>The Joy of Rails icon will now be added to your home screen.</li>

--- a/app/views/pwa/installation_instructions/user_agents/_ios_safari.html.erb
+++ b/app/views/pwa/installation_instructions/user_agents/_ios_safari.html.erb
@@ -1,6 +1,6 @@
-<p>To add this web app to your home screen on iOS:</p>
+<p>To add this web app to your home screen on <%= @installation_instructions.os_name %>:</p>
 <ol>
-  <li>Tap the <strong>Share</strong> button at the bottom of the screen.</li>
+  <li>Tap the <strong>Share</strong> button.</li>
   <li>Scroll down and tap <strong>Add to Home Screen</strong>.</li>
   <li>Customize the name of the app (optional) and tap <strong>Add</strong>.</li>
   <li>The Joy of Rails icon will now be added to your home screen.</li>

--- a/app/views/pwa/installation_instructions/user_agents/_ipados_chrome.html.erb
+++ b/app/views/pwa/installation_instructions/user_agents/_ipados_chrome.html.erb
@@ -1,0 +1,1 @@
+<%= render "pwa/installation_instructions/user_agents/ios_chrome" %>

--- a/app/views/pwa/installation_instructions/user_agents/_ipados_edge.html.erb
+++ b/app/views/pwa/installation_instructions/user_agents/_ipados_edge.html.erb
@@ -1,0 +1,1 @@
+<%= render "pwa/installation_instructions/user_agents/ios_edge" %>

--- a/app/views/pwa/installation_instructions/user_agents/_ipados_firefox.html.erb
+++ b/app/views/pwa/installation_instructions/user_agents/_ipados_firefox.html.erb
@@ -1,0 +1,1 @@
+<%= render "pwa/installation_instructions/user_agents/ios_firefox" %>

--- a/app/views/pwa/installation_instructions/user_agents/_ipados_safari.html.erb
+++ b/app/views/pwa/installation_instructions/user_agents/_ipados_safari.html.erb
@@ -1,0 +1,1 @@
+<%= render "pwa/installation_instructions/user_agents/ios_safari" %>


### PR DESCRIPTION
Installation instructions show as "unsupported" for iPadOS. This PR adds basic iPadOS instructions, borrowing from iOS.

Also improves the title-zation of iOS, macOS, and iPadOS.