### PR TITLE
Bump webrick for CVE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -585,7 +585,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
+    webrick (1.8.2)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
ruby-advisory-db:
  advisories:   929 advisories
  last updated: 2024-09-23 19:56:34 -0700
  commit:       9abfcb29a8e6be1fc9f0866a65de58e2d4a0104f
Name: webrick
Version: 1.8.1
CVE: CVE-2024-47220
GHSA: GHSA-6f62-3596-g6w7
Criticality: High
URL: https://github.com/advisories/GHSA-6f62-3596-g6w7
Title: HTTP Request Smuggling in ruby webrick
Solution: upgrade to '>= 1.8.2'

<!-- Describe your changes and link to relevant issues or discussions. Please add motivation and context as needed. -->

## Pull request checklist

- [ ] I have written tests for code I have added or modified.
- [ ] I linted and tested the project with `bin/verify`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
