### PR TITLE
Convert custom settings to config.x

### DIFF
--- a/app/clients/postmark_client.rb
+++ b/app/clients/postmark_client.rb
@@ -8,6 +8,6 @@ class PostmarkClient
   end
 
   def api_client
-    @api_client ||= Postmark::ApiClient.new(Rails.configuration.settings.postmark_api_token)
+    @api_client ||= Postmark::ApiClient.new(Rails.configuration.x.postmark.api_token)
   end
 end

--- a/app/controllers/color_schemes_controller.rb
+++ b/app/controllers/color_schemes_controller.rb
@@ -8,7 +8,7 @@ class ColorSchemesController < ApplicationController
   def show
     @color_scheme = ColorScheme.find(params[:id])
 
-    if Rails.configuration.settings.skip_http_cache? || stale?(@color_scheme, public: true)
+    if Rails.configuration.skip_http_cache || stale?(@color_scheme, public: true)
       respond_to do |format|
         format.html { render ColorSchemes::ShowView.new(color_scheme: @color_scheme) }
         format.css { render ColorSchemes::Css.new(color_scheme: @color_scheme), layout: false }

--- a/app/controllers/feed_controller.rb
+++ b/app/controllers/feed_controller.rb
@@ -2,7 +2,7 @@ class FeedController < ApplicationController
   def index
     @articles = ArticlePage.published
 
-    if Rails.configuration.settings.skip_http_cache? || stale?(@articles, public: true)
+    if Rails.configuration.skip_http_cache || stale?(@articles, public: true)
       respond_to do |format|
         format.html { redirect_to feed_path(format: :atom), status: :moved_permanently }
         format.atom

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -35,7 +35,7 @@ class SiteController < Sitepress::SiteController
   end
 
   def skip_http_cache?
-    Rails.configuration.settings.skip_http_cache? || current_path?(root_path) || custom_color_scheme? || custom_syntax_highlight?
+    Rails.configuration.skip_http_cache || current_path?(root_path) || custom_color_scheme? || custom_syntax_highlight?
   end
 
   def current_path?(path)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,12 +11,12 @@ module ApplicationHelper
       description: :description,
       type: "article",
       url: url_for,
-      site_name: Rails.configuration.settings.application_name,
+      site_name: Rails.configuration.x.application_name,
       locale: "en_US"
     }
     set_meta_tags twitter: {
       site: "@joyofrails"
     }
-    display_meta_tags site: Rails.configuration.settings.application_name
+    display_meta_tags site: Rails.configuration.x.application_name
   end
 end

--- a/app/helpers/pwa_helper.rb
+++ b/app/helpers/pwa_helper.rb
@@ -6,6 +6,6 @@ module PwaHelper
   # which is not necessary for the WebPush API and just doesn't feel like a nice API.
   #
   def web_push_key
-    Rails.application.credentials.vapid.public_key.delete("=")
+    Rails.configuration.x.vapid.public_key
   end
 end

--- a/app/jobs/pwa/web_push_job.rb
+++ b/app/jobs/pwa/web_push_job.rb
@@ -14,9 +14,9 @@ class Pwa::WebPushJob < ApplicationJob
       p256dh: subscription["keys"]["p256dh"],
       auth: subscription["keys"]["auth"],
       vapid: {
-        subject: Rails.application.credentials.vapid.subject,
-        public_key: Rails.application.credentials.vapid.public_key,
-        private_key: Rails.application.credentials.vapid.private_key
+        subject: Rails.configuration.x.vapid.subject,
+        public_key: Rails.configuration.x.vapid.public_key,
+        private_key: Rails.configuration.x.vapid.private_key
       },
       ssl_timeout: 5, # optional value for Net::HTTP#ssl_timeout=
       open_timeout: 5, # optional value for Net::HTTP#open_timeout=

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,14 +3,14 @@
 class ApplicationMailer < ActionMailer::Base
   prepend_view_path "app/views/emails"
 
-  FROM_ADDRESS = Rails.configuration.settings.emails.transactional_from_address
-  FROM_NAME = Rails.configuration.settings.emails.transactional_from_name
+  FROM_ADDRESS = Rails.configuration.x.emails.transactional_from_address
+  FROM_NAME = Rails.configuration.x.emails.transactional_from_name
 
   default from: email_address_with_name(FROM_ADDRESS, FROM_NAME)
   layout "emails/mailer"
 
   def self.test_recipients
-    [Rails.configuration.settings.emails.test_recipient].compact
+    [Rails.configuration.x.emails.test_recipient].compact
   end
 
   def support_email

--- a/app/mailers/emails/newsletter_mailer.rb
+++ b/app/mailers/emails/newsletter_mailer.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 class Emails::NewsletterMailer < ApplicationMailer
-  NEWSLETTER_EMAIL = Rails.configuration.settings.emails.broadcast_from_address
-
   default from: email_address_with_name(
-    Rails.configuration.settings.emails.broadcast_from_address,
-    "Ross from Joy of Rails"
+    Rails.configuration.x.emails.broadcast_from_address,
+    Rails.configuration.x.emails.broadcast_from_name
   )
 
   def newsletter(newsletter:, user:, unsubscribe_token:)

--- a/app/views/components/layouts/front_door_form.rb
+++ b/app/views/components/layouts/front_door_form.rb
@@ -20,7 +20,7 @@ class Layouts::FrontDoorForm < Phlex::HTML
         svg_tag "joy-logo.svg",
           class: "fill-current mx-auto",
           style: "max-width: 64px;",
-          alt: Rails.configuration.settings.application_name
+          alt: Rails.configuration.x.application_name
         h2(
           class: "mt-4 text-center text-2xl text-theme font-bold leading-9 tracking-tight"
         ) { @title }

--- a/app/views/feed/index.atom.builder
+++ b/app/views/feed/index.atom.builder
@@ -1,5 +1,5 @@
 atom_feed do |feed|
-  feed.title(Rails.configuration.settings.application_name)
+  feed.title(Rails.configuration.x.application_name)
   feed.updated(@articles.first.published_on) if @articles.length > 0
 
   @articles.take(50).each do |article|

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,7 +1,7 @@
 {
   "id": "joy-of-rails",
-  "name": "<%= Rails.configuration.settings.application_name %>",
-  "short_name": "<%= Rails.configuration.settings.application_name %>",
+  "name": "<%= Rails.configuration.x.application_name %>",
+  "short_name": "<%= Rails.configuration.x.application_name %>",
   "description": "A place to learn about Ruby on Rails and how it makes web development a joy",
   "start_url": "<%= root_url %>",
   "theme_color": "<%= @color_scheme.weight_200.hex.to_s %>",

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,7 +60,6 @@ module Joy
     # Set up custom settings
     config.settings = ActiveSupport::OrderedOptions.new
 
-    config.settings.postmark_api_token = Rails.application.credentials.postmark&.api_token || "POSTMARK_API_TEST"
     config.settings.skip_http_cache = ENV["SKIP_HTTP_CACHE"] == "true"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,7 +60,6 @@ module Joy
     # Set up custom settings
     config.settings = ActiveSupport::OrderedOptions.new
 
-    config.settings.application_name = "Joy of Rails"
     config.settings.postmark_api_token = Rails.application.credentials.postmark&.api_token || "POSTMARK_API_TEST"
     config.settings.skip_http_cache = ENV["SKIP_HTTP_CACHE"] == "true"
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,8 +56,5 @@ module Joy
     if ENV["RAILS_LOG_TO_STDOUT"] == "true"
       config.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new($stdout))
     end
-
-    # Set up custom settings
-    config.settings = ActiveSupport::OrderedOptions.new
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -59,7 +59,5 @@ module Joy
 
     # Set up custom settings
     config.settings = ActiveSupport::OrderedOptions.new
-
-    config.settings.skip_http_cache = ENV["SKIP_HTTP_CACHE"] == "true"
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -92,10 +92,4 @@ Rails.application.configure do
   config.solid_queue.connects_to = {database: {writing: :queue, reading: :queue}}
 
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "debug")
-
-  config.settings.postmark_api_token = if ENV["ENABLE_POSTMARK_IN_DEV"] == "true"
-    Rails.application.credentials.postmark&.api_token || "POSTMARK_API_TEST"
-  else
-    "POSTMARK_API_TEST"
-  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,7 +77,6 @@ Rails.application.configure do
 
   # Configure Postmark
   config.action_mailer.delivery_method = :postmark
-  config.action_mailer.postmark_settings = {api_token: config.settings.postmark_api_token}
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/emails.rb
+++ b/config/initializers/emails.rb
@@ -1,11 +1,9 @@
 Rails.application.configure do
-  config.settings.emails = ActiveSupport::OrderedOptions.new
+  credentials = Rails.application.credentials
 
-  emails = Rails.application.credentials.emails
-
-  config.settings.emails.transactional_from_address = emails&.transactional_from_address || "hello@example.com"
-  config.settings.emails.transactional_from_name = emails&.transactional_from_name || "Joy of Rails"
-  config.settings.emails.broadcast_from_address = emails&.broadcast_from_address || "hello@example.com"
-  config.settings.emails.broadcast_from_name = emails&.broadcast_from_name || "Joy of Rails"
-  config.settings.emails.test_recipient = emails&.test_recipient || "hello@example.com"
+  config.x.emails.transactional_from_address = credentials.dig(:transactional_from_address) || "hello@example.com"
+  config.x.emails.transactional_from_name = credentials.dig(:transactional_from_name) || "Joy of Rails"
+  config.x.emails.broadcast_from_address = credentials.dig(:broadcast_from_address) || "hello@example.com"
+  config.x.emails.broadcast_from_name = credentials.dig(:broadcast_from_name) || "Joy of Rails"
+  config.x.emails.test_recipient = credentials.dig(:test_recipient) || "hello@example.com"
 end

--- a/config/initializers/http_cache.rb
+++ b/config/initializers/http_cache.rb
@@ -1,0 +1,3 @@
+Rails.application.configure do
+  config.skip_http_cache = ENV["SKIP_HTTP_CACHE"] == "true"
+end

--- a/config/initializers/joy.rb
+++ b/config/initializers/joy.rb
@@ -1,0 +1,3 @@
+Rails.application.configure do
+  config.x.application_name = "Joy of Rails"
+end

--- a/config/initializers/postmark.rb
+++ b/config/initializers/postmark.rb
@@ -1,0 +1,9 @@
+Rails.application.configure do
+  config.x.postmark.api_token = Rails.application.credentials.dig(:postmark, :api_token) || "POSTMARK_API_TEST"
+
+  config.action_mailer.postmark_settings = {api_token: config.x.postmark.api_token}
+
+  if Rails.env.local? && ENV["ENABLE_POSTMARK_IN_DEV"] == "true"
+    config.action_mailer.delivery_method = :postmark
+  end
+end

--- a/config/initializers/vapid.rb
+++ b/config/initializers/vapid.rb
@@ -1,0 +1,16 @@
+Rails.application.configure do
+  # The VAPID public key is used to identify the server that is sending the web push notification.
+  # To regenerate the VAPID keys, run the following command:
+  # bin/rails runner "puts WebPush.generate_key.to_h.to_yaml"
+  #
+  # The Ruby WebPush library can produce a padded public key unncessarily.
+  # We delete the trailing "=" from the public key so we can subscribe in JavaScript
+  # (i.e. registration.pushManager.subscribe({ applicationServerKey: webPushKey }))
+  # with the raw key; otherwise we have to convert to a Uint8Array as most docs suggest
+  # which is not necessary for the WebPush API and just doesn't feel like a nice API.
+  #
+  config.x.vapid.public_key = Rails.application.credentials.dig(:vapid, :public_key).to_s.delete("=") # The VAPID public key
+  config.x.vapid.private_key = Rails.application.credentials.dig(:vapid, :private_key).to_s.delete("=") # The VAPID private key
+
+  config.x.vapid.subject = Rails.application.credentials.dig(:vapid, :subject) # The "mailto:" email address
+end

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -7,7 +7,7 @@ AdminUser.find_or_create_by!(
 end
 
 User.find_or_create_by(
-  email: Rails.configuration.settings.emails.test_recipient
+  email: Rails.configuration.x.emails.test_recipient
 ) do |u|
   u.password = "password"
   u.password_confirmation = "password"

--- a/spec/config/x_spec.rb
+++ b/spec/config/x_spec.rb
@@ -10,4 +10,8 @@ RSpec.describe "Custom configuration" do
     it { expect(Rails.configuration.x.vapid.public_key.length).to eq(87) }
     it { expect(Rails.configuration.x.vapid.private_key.length).to eq(43) }
   end
+
+  describe "#postmark" do
+    it { expect(Rails.configuration.x.postmark.api_token).to eq("POSTMARK_API_TEST") }
+  end
 end

--- a/spec/config/x_spec.rb
+++ b/spec/config/x_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe "Custom configuration" do
 
   describe "#vapid" do
     it { expect(Rails.configuration.x.vapid.subject).to eq("mailto:hello@example.com") }
-    it { expect(Rails.configuration.x.vapid.public_key.length).to eq(87) }
-    it { expect(Rails.configuration.x.vapid.private_key.length).to eq(43) }
+    it { expect(Rails.configuration.x.vapid.public_key).to be_present }
+    it { expect(Rails.configuration.x.vapid.private_key).to be_present }
   end
 
   describe "#postmark" do

--- a/spec/config/x_spec.rb
+++ b/spec/config/x_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe "Custom configuration" do
+  describe "#vapid" do
+    it { expect(Rails.configuration.x.vapid.subject).to eq("mailto:hello@example.com") }
+    it { expect(Rails.configuration.x.vapid.public_key.length).to eq(87) }
+    it { expect(Rails.configuration.x.vapid.private_key.length).to eq(43) }
+  end
+end

--- a/spec/config/x_spec.rb
+++ b/spec/config/x_spec.rb
@@ -18,4 +18,12 @@ RSpec.describe "Custom configuration" do
   describe "#skip_http_cache" do
     it { expect(Rails.configuration.skip_http_cache).to eq(false) }
   end
+
+  describe "#emails" do
+    it { expect(Rails.configuration.x.emails.transactional_from_address).to eq "hello@example.com" }
+    it { expect(Rails.configuration.x.emails.transactional_from_name).to eq "Joy of Rails" }
+    it { expect(Rails.configuration.x.emails.broadcast_from_address).to eq "hello@example.com" }
+    it { expect(Rails.configuration.x.emails.broadcast_from_name).to eq "Joy of Rails" }
+    it { expect(Rails.configuration.x.emails.test_recipient).to eq "hello@example.com" }
+  end
 end

--- a/spec/config/x_spec.rb
+++ b/spec/config/x_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "Custom configuration" do
+  describe "#application_name" do
+    it { expect(Rails.configuration.x.application_name).to eq("Joy of Rails") }
+  end
+
   describe "#vapid" do
     it { expect(Rails.configuration.x.vapid.subject).to eq("mailto:hello@example.com") }
     it { expect(Rails.configuration.x.vapid.public_key.length).to eq(87) }

--- a/spec/config/x_spec.rb
+++ b/spec/config/x_spec.rb
@@ -14,4 +14,8 @@ RSpec.describe "Custom configuration" do
   describe "#postmark" do
     it { expect(Rails.configuration.x.postmark.api_token).to eq("POSTMARK_API_TEST") }
   end
+
+  describe "#skip_http_cache" do
+    it { expect(Rails.configuration.skip_http_cache).to eq(false) }
+  end
 end

--- a/spec/requests/pwa/web_pushes_spec.rb
+++ b/spec/requests/pwa/web_pushes_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe "/pwa/web_pushes", type: :request do
         p256dh: subscription.dig(:keys, :p256dh),
         auth: subscription.dig(:keys, :auth),
         vapid: {
-          subject: Rails.application.credentials.vapid.subject,
-          public_key: Rails.application.credentials.vapid.public_key,
-          private_key: Rails.application.credentials.vapid.private_key
+          subject: Rails.configuration.x.vapid.subject,
+          public_key: Rails.configuration.x.vapid.public_key,
+          private_key: Rails.configuration.x.vapid.private_key
         },
         ssl_timeout: kind_of(Integer),
         open_timeout: kind_of(Integer),

--- a/spec/system/admin/newsletter_spec.rb
+++ b/spec/system/admin/newsletter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Admin for Newsletters", type: :system do
 
   it "send a newsletter test", :vcr do
     newsletter = FactoryBot.create(:newsletter)
-    test_recipient_email = Rails.configuration.settings.emails.test_recipient
+    test_recipient_email = Rails.configuration.x.emails.test_recipient
     FactoryBot.create(:user, :confirmed, :subscribed, email: test_recipient_email)
 
     allow(PostmarkClient).to receive(:deliver_messages).and_call_original


### PR DESCRIPTION
Rails provides a custom configuration namespace called `config.x` https://guides.rubyonrails.org/configuring.html#custom-configuration

I had been using a custom ordered options settings object to do the same thing. There‘s nothing wrong with this approach, but this PR converges on the out-of-the-box `config.x` object to be more like the Rails way.
