### PR TITLE
Add addressable to Gemfile for production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem "warden" # General Rack Authentication Framework [https://github.com/wardenc
 gem "postmark-rails" # Postmark Rails gem [https://github.com/ActiveCampaign/postmark-rails]
 gem "scout_apm" # Scout APM Ruby Agent [https://scoutapm.com]
 gem "rails_admin" # RailsAdmin is a Rails engine that provides an easy-to-use interface for managing your data [https://github.com/railsadminteam/rails_admin]
+gem "addressable" # Addressable is an alternative implementation to URI [https://github.com/sporkmonger/addressable]
 
 # Rendering
 gem "image_processing" # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -575,6 +575,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  addressable
   aws-sdk-s3
   bcrypt (~> 3.1.7)
   bootsnap

--- a/app/models/gravatar.rb
+++ b/app/models/gravatar.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "addressable"
+require "addressable/template"
 
 class Gravatar
   # Gravatar URI template


### PR DESCRIPTION
Production server is not able to start:

```
$ bundle exec --keep-file-descriptors puma -b tcp://127.0.0.1:5001
[807398] Puma starting in cluster mode...
[807398] * Puma version: 6.4.3 (ruby 3.3.4-p94) ("The Eagle of Durango")
[807398] *  Min threads: 3
[807398] *  Max threads: 3
[807398] *  Environment: production
[807398] *   Master PID: 807398
[807398] *      Workers: 2
[807398] *     Restarts: (✔) hot (✖) phased
[807398] * Preloading application
[DEPRECATED] Bundler.rubygems.all_specs has been removed in favor of Bundler.rubygems.installed_specs
[807398] ! Unable to load application: LoadError: cannot load such file -- addressable
bundler: failed to load command: puma (~/joyofrails/shared/bundle/ruby/3.3.0/bin/puma)
I, [2024-10-20T12:58:44.262145 #807398]  INFO -- honeybadger: ** [Honeybadger] Reporting error id=acd927a6-877e-4a87-8fd6-1755db589716 level=1 pid=807398
W, [2024-10-20T12:58:44.495193 #807398]  WARN -- honeybadger: ** [Honeybadger] Error report failed: project is sending too many errors. id=acd927a6-877e-4a87-8fd6-1755db589716 code=429 throttle=1 interval=0.05 level=2 pid=807398
~/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require': cannot load such file -- addressable (LoadError)
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:27:in `require'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
	from ~/joyofrails/releases/20241019162834/app/models/gravatar.rb:3:in `<main>'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:26:in `require'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/cref.rb:91:in `const_get'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/cref.rb:91:in `get'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/loader/eager_load.rb:173:in `block in actual_eager_load_dir'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/loader/helpers.rb:47:in `block in ls'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/loader/helpers.rb:25:in `each'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/loader/helpers.rb:25:in `ls'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/loader/eager_load.rb:168:in `actual_eager_load_dir'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/loader/eager_load.rb:17:in `block (2 levels) in eager_load'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/loader/eager_load.rb:16:in `each'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/loader/eager_load.rb:16:in `block in eager_load'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/loader/eager_load.rb:10:in `synchronize'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/loader/eager_load.rb:10:in `eager_load'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/loader.rb:413:in `block in eager_load_all'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/loader.rb:411:in `each'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/zeitwerk-2.6.18/lib/zeitwerk/loader.rb:411:in `eager_load_all'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/railties-8.0.0.beta1/lib/rails/application/finisher.rb:80:in `block in <module:Finisher>'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/railties-8.0.0.beta1/lib/rails/initializable.rb:32:in `instance_exec'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/railties-8.0.0.beta1/lib/rails/initializable.rb:32:in `run'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/railties-8.0.0.beta1/lib/rails/initializable.rb:61:in `block in run_initializers'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:231:in `block in tsort_each'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:353:in `block (2 levels) in each_strongly_connected_component'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:434:in `each_strongly_connected_component_from'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:352:in `block in each_strongly_connected_component'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:350:in `each'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:350:in `call'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:350:in `each_strongly_connected_component'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:229:in `tsort_each'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:208:in `tsort_each'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/railties-8.0.0.beta1/lib/rails/initializable.rb:60:in `run_initializers'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/railties-8.0.0.beta1/lib/rails/application.rb:440:in `initialize!'
	from ~/joyofrails/releases/20241019162834/config/environment.rb:5:in `<top (required)>'
	from config.ru:3:in `require_relative'
	from config.ru:3:in `block (2 levels) in <top (required)>'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/rack-3.1.7/lib/rack/builder.rb:108:in `eval'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/rack-3.1.7/lib/rack/builder.rb:108:in `new_from_string'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/rack-3.1.7/lib/rack/builder.rb:97:in `load_file'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/rack-3.1.7/lib/rack/builder.rb:67:in `parse_file'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/configuration.rb:368:in `load_rackup'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/configuration.rb:290:in `app'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/runner.rb:162:in `load_and_bind'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/cluster.rb:371:in `run'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/launcher.rb:194:in `run'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/cli.rb:75:in `run'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/gems/puma-6.4.3/bin/puma:10:in `<top (required)>'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/bin/puma:25:in `load'
	from ~/joyofrails/shared/bundle/ruby/3.3.0/bin/puma:25:in `<top (required)>'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.19/lib/bundler/cli/exec.rb:58:in `load'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.19/lib/bundler/cli/exec.rb:58:in `kernel_load'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.19/lib/bundler/cli/exec.rb:23:in `run'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.19/lib/bundler/cli.rb:455:in `exec'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.19/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.19/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.19/lib/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.19/lib/bundler/cli.rb:35:in `dispatch'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.19/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.19/lib/bundler/cli.rb:29:in `start'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.19/exe/bundle:28:in `block in <top (required)>'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.19/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
	from ~/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.19/exe/bundle:20:in `<top (required)>'
	from ~/.asdf/installs/ruby/3.3.4/bin/bundle:25:in `load'
	from ~/.asdf/installs/ruby/3.3.4/bin/bundle:25:in `<main>'
```