### PR TITLE
MIGRATION Prepare for solid queue 0.5.0

### DIFF
--- a/db/migrate_queue/20241025133648_create_recurring_tasks.solid_queue.rb
+++ b/db/migrate_queue/20241025133648_create_recurring_tasks.solid_queue.rb
@@ -1,0 +1,21 @@
+# This migration comes from solid_queue (originally 20240719134516)
+class CreateRecurringTasks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :solid_queue_recurring_tasks do |t|
+      t.string :key, null: false, index: {unique: true}
+      t.string :schedule, null: false
+      t.string :command, limit: 2048
+      t.string :class_name
+      t.text :arguments
+
+      t.string :queue_name
+      t.integer :priority, default: 0
+
+      t.boolean :static, default: true, index: true
+
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_27_193607) do
+ActiveRecord::Schema[8.0].define(version: 2024_10_25_133648) do
   create_table "_litestream_lock", id: false, force: :cascade do |t|
     t.integer "id"
   end
@@ -107,6 +107,22 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_27_193607) do
     t.datetime "created_at", null: false
     t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
     t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "schedule", null: false
+    t.string "command", limit: 2048
+    t.string "class_name"
+    t.text "arguments"
+    t.string "queue_name"
+    t.integer "priority", default: 0
+    t.boolean "static", default: true
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
   end
 
   create_table "solid_queue_scheduled_executions", force: :cascade do |t|


### PR DESCRIPTION
Add migration for Solid Queue 0.5.0

```
bin/rails solid_queue:install:migrations DATABASE=queue
```

More info https://github.com/rails/solid_queue/blob/main/UPGRADING.md
