### PR TITLE
Fix typos

### DIFF
--- a/app/content/models/sitepress_article.rb
+++ b/app/content/models/sitepress_article.rb
@@ -1,4 +1,4 @@
-class ArticlePage < Sitepress::Model
+class SitepressArticle < Sitepress::Model
   extend ActiveModel::Naming
   include ActiveModel::Conversion
 

--- a/app/content/models/sitepress_page.rb
+++ b/app/content/models/sitepress_page.rb
@@ -1,4 +1,4 @@
-class Page < Sitepress::Model
+class SitepressPage < Sitepress::Model
   collection glob: "**/*.html*"
   data :title
 end

--- a/app/content/pages/articles/index.html.erb
+++ b/app/content/pages/articles/index.html.erb
@@ -9,7 +9,7 @@ description: Read the latest articles from Joy of Rails
     description: "Read the latest articles from Joy of Rails"
   ) %>
   <div class="main-content container py-gap">
-    <%= render Pages::List.new(ArticlePage.published(params)) %>
+    <%= render Pages::List.new(SitepressArticle.published(params)) %>
   </div>
 </section>
 <section>

--- a/app/content/pages/articles/web-push-notifications-from-rails.html.mdrb
+++ b/app/content/pages/articles/web-push-notifications-from-rails.html.mdrb
@@ -156,7 +156,7 @@ Before a Web Push message can be delivered, a few criteria should be satisfied:
 
 ## The Manifest
 
-Previously, I wrote about the manifest file in [Add your Rails app to the Home Screen - the Ultimate Guide](articles/add-your-rails-app-to-the-home-screen). I’ve provided a quick recap below.
+Previously, I wrote about the manifest file in [Add your Rails app to the Home Screen - the Ultimate Guide](/articles/add-your-rails-app-to-the-home-screen). I’ve provided a quick recap below.
 
 Since the Rails 7.2, Rails provides defaults for Progressive Web App manifest JSON and serviceworker JavaScript files ([pull request](https://github.com/rails/rails/pull/50528)).
 

--- a/app/content/pages/articles/web-push-notifications-from-rails.html.mdrb
+++ b/app/content/pages/articles/web-push-notifications-from-rails.html.mdrb
@@ -32,15 +32,15 @@ First click the Subscribe button below. You may have also need to accept a brows
 
 <%= render Pwa::WebPushDemo.new %>
 
-I‘m not persisting this subscription in any way so you will only receive a notification if you click that button. You can also click "Unsubscribe" to register your browser at any time.
+I’m not persisting this subscription in any way so you will only receive a notification if you click that button. You can also click "Unsubscribe" to register your browser at any time.
 
 ## Troubleshooting
 
-If you‘re interested in sending Web Push notifications, then it will be good to know why they might work.
+If you’re interested in sending Web Push notifications, then it will be good to know why they might work.
 
 ### Browser support
 
-Most web browsers support Web Push notifications (according to [caniuse.com](https://caniuse.com/?search=web%20push)), but let‘s check:
+Most web browsers support Web Push notifications (according to [caniuse.com](https://caniuse.com/?search=web%20push)), but let’s check:
 
 <%= render partial: "pwa/web_pushes/test" %>
 
@@ -62,7 +62,7 @@ You can use the install button above to either launch the installation prompt in
 
 ### Browser notification settings
 
-You may have been able to Subscribe to Web Push but you still didn’t get a notification. If you’re in a supported browser, it‘s possible that notifications are disabled in your browser which means when the Web Push event is received the Service Worker won’t be able to trigger a notification. ![Screenshot](articles/web-push-notifications-from-rails/chrome-macos-notifications-permissions.jpg 'Google Chrome Notifications setting from address bar | {"class":"pull-right"}')
+You may have been able to Subscribe to Web Push but you still didn’t get a notification. If you’re in a supported browser, it’s possible that notifications are disabled in your browser which means when the Web Push event is received the Service Worker won’t be able to trigger a notification. ![Screenshot](articles/web-push-notifications-from-rails/chrome-macos-notifications-permissions.jpg 'Google Chrome Notifications setting from address bar | {"class":"pull-right"}')
 
 Try checking your Notification settings. This setting can be controlled per origin. In Chrome for macOS, for example, you should be able to check your Notification settings for any site from the address bar.
 
@@ -72,15 +72,15 @@ You also might need to check you operating System Settings.
 
 In macOS, for example, you may need to go to the System Settings app and the Notifications settings for your browser: ![System Settings Notifications Chrome](articles/web-push-notifications-from-rails/system-settings-notifications.jpg 'macOS System Settings > Notifications > Google Chrome | {"class":"pull-right row-span-2"}')
 
-System Settings on macOS also has a Focus tab with a Do Not Disturb feature. It‘s easy to forget about this one—ask me how I found that out while testing this article after hours. ![System Settings Focus Do Not Disturb](articles/web-push-notifications-from-rails/system-settings-focus-do-no-disturb.jpg 'macOS System Settings > Focus > Do Not Disturb | {"class":"pull-right row-span-2"}')
+System Settings on macOS also has a Focus tab with a Do Not Disturb feature. It’s easy to forget about this one—ask me how I found that out while testing this article after hours. ![System Settings Focus Do Not Disturb](articles/web-push-notifications-from-rails/system-settings-focus-do-no-disturb.jpg 'macOS System Settings > Focus > Do Not Disturb | {"class":"pull-right row-span-2"}')
 
 ### Expired Subscriptions
 
-Another reason a Web Push notification fails to deliver could be because your browser‘s Web Push subscription to this site has gone stale. This may be unlikely if this is the first time visiting the site, but the likelihood increases especially if you‘re coming back to the site after some time. So you could try resubscribing using the buttons above.
+Another reason a Web Push notification fails to deliver could be because your browser’s Web Push subscription to this site has gone stale. This may be unlikely if this is the first time visiting the site, but the likelihood increases especially if you’re coming back to the site after some time. So you could try resubscribing using the buttons above.
 
 ### Bug 🐞 ???
 
-Finally, it‘s possible I’ve introduced a regression since the last time I tested, so you could check your web browser’s dev tools for JavaScript errors. Feel free to [report an issue on GitHub](https://github.com/joyofrails/joyofrails.com/issues) with supporting information if you think there’s a bug.
+Finally, it’s possible I’ve introduced a regression since the last time I tested, so you could check your web browser’s dev tools for JavaScript errors. Feel free to [report an issue on GitHub](https://github.com/joyofrails/joyofrails.com/issues) with supporting information if you think there’s a bug.
 
 ## How does it work?
 
@@ -156,7 +156,7 @@ Before a Web Push message can be delivered, a few criteria should be satisfied:
 
 ## The Manifest
 
-Previously, I wrote about the manifest file in [Add your Rails app to the Home Screen - the Ultimate Guide](articles/add-your-rails-app-to-the-home-screen). I‘ve provided a quick recap below.
+Previously, I wrote about the manifest file in [Add your Rails app to the Home Screen - the Ultimate Guide](articles/add-your-rails-app-to-the-home-screen). I’ve provided a quick recap below.
 
 Since the Rails 7.2, Rails provides defaults for Progressive Web App manifest JSON and serviceworker JavaScript files ([pull request](https://github.com/rails/rails/pull/50528)).
 
@@ -189,7 +189,7 @@ You should also have corresponding files in `app/views/pwa`:
 - `manifest.json.erb`
 - `serviceworker.js.erb`
 
-_What if my app isn’t on Rails 7.2?_ That‘s ok! If you can’t upgrade now, you can still set up your Rails app similarly. Simply copy the files and routes changes as described here.
+_What if my app isn’t on Rails 7.2?_ That’s ok! If you can’t upgrade now, you can still set up your Rails app similarly. Simply copy the files and routes changes as described here.
 
 For a newly generated Rails 7.2 application, this is what you’ll see in `manifest.json.erb`:
 

--- a/app/content/pages/drafts.html.erb
+++ b/app/content/pages/drafts.html.erb
@@ -2,7 +2,7 @@
   <section class="max-w-screen-lg py-16 mx-auto lg:py-20">
     <h1 class="pb-16 text-2xl font-bold text-center md:text-4xl">Drafts</h1>
     <section class="grid grid-cols-1 gap-8 md:grid-cols-2 md:gap-16">
-      <% ArticlePage.draft.each do |page| %>
+      <% SitepressArticle.draft.each do |page| %>
         <article class="flex flex-col">
           <%= link_to_page page do %>
             <h2 class="text-xl font-bold md:text-2xl leading-tighter"><%= page.title %></h2>
@@ -12,7 +12,7 @@
               <div class="flex flex-col w-40">
                 <div class="leading-tight text-gray-500 place-content-end opacity-90">
                   <div>
-                    Unbpublished
+                    Unpublished
                   </div>
                 </div>
               </div>

--- a/app/content/pages/index.html.erb
+++ b/app/content/pages/index.html.erb
@@ -2,7 +2,7 @@
 title: Joy of Rails
 ---
 
-<% articles = ArticlePage.published(params) %>
+<% articles = SitepressArticle.published(params) %>
 <section style="min-height: 51vh">
   <div class="main-content container py-gap lg:py-3xl">
     <% articles.take(3).zip(%w[left right].cycle).each do |(page, side)| %>

--- a/app/controllers/feed_controller.rb
+++ b/app/controllers/feed_controller.rb
@@ -1,6 +1,6 @@
 class FeedController < ApplicationController
   def index
-    @articles = ArticlePage.published
+    @articles = SitepressArticle.published
 
     if Rails.configuration.skip_http_cache || stale?(@articles, public: true)
       respond_to do |format|

--- a/app/views/users/thank_yous/show_view.rb
+++ b/app/views/users/thank_yous/show_view.rb
@@ -27,7 +27,7 @@ class Users::ThankYous::ShowView < ApplicationView
             strong { link_to("articles", "/articles") }
             whitespace
             plain "I’ve written on Ruby, Rails, and Hotwire."
-            if ArticlePage.published.length < 5
+            if SitepressArticle.published.length < 5
               whitespace
               plain "I’m working on adding some new content, so check back soon!"
             end

--- a/spec/requests/site/articles_spec.rb
+++ b/spec/requests/site/articles_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "Site: articles" do
-  let(:first_article) { ArticlePage.published.first }
+  let(:first_article) { SitepressArticle.published.first }
 
   # Filter out index.html.erb from article pages before selecting first draft
-  let(:first_draft) { ArticlePage.draft.lazy.filter { |article| article.page.request_path != "/articles" }.first }
+  let(:first_draft) { SitepressArticle.draft.lazy.filter { |article| article.page.request_path != "/articles" }.first }
 
   describe "GET /" do
     it "lists recent published articles" do

--- a/spec/views/components/atom/entry_content_spec.rb
+++ b/spec/views/components/atom/entry_content_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Atom::EntryContent do
-  let(:article) { ArticlePage.published.find { |a| a.title == "Introducing Joy of Rails" } } # introducing_joy_of_rails.mdrb
+  let(:article) { SitepressArticle.published.find { |a| a.title == "Introducing Joy of Rails" } } # introducing_joy_of_rails.mdrb
 
   describe "#render" do
     it "renders the article body as html without enhanced markdown" do


### PR DESCRIPTION
Also, renames sitepress models to distinguish from eventual active record model names I’d like to use.