### PR TITLE
Add search query parser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "scout_apm" # Scout APM Ruby Agent [https://scoutapm.com]
 gem "rails_admin" # RailsAdmin is a Rails engine that provides an easy-to-use interface for managing your data [https://github.com/railsadminteam/rails_admin]
 gem "addressable" # Addressable is an alternative implementation to URI [https://github.com/sporkmonger/addressable]
 gem "ostruct" # OpenStruct is a data structure, similar to a Hash, that allows the definition of arbitrary attributes with their accompanying values
+gem "parslet" # Parslet is a small Ruby library for constructing parsers [https://github.com/kschiess/parslet]
 
 # Rendering
 gem "image_processing" # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,6 +337,7 @@ GEM
     parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
+    parslet (2.0.0)
     phlex (2.0.0.beta2)
     phlex-rails (2.0.0.beta2)
       phlex (= 2.0.0.beta2)
@@ -621,6 +622,7 @@ DEPENDENCIES
   meta-tags
   mission_control-jobs
   ostruct
+  parslet
   phlex (= 2.0.0.beta2)
   phlex-rails (= 2.0.0.beta2)
   postmark-rails

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -10,7 +10,7 @@ class SearchesController < ApplicationController
     @raw_query = params[:query] || ""
     pages = if @raw_query.present?
       query = Searches::Query.parse!(@raw_query)
-      Page.search(query.to_s).limit(3)
+      Page.search("#{query}*").with_snippets.ranked.limit(3)
     else
       []
     end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,12 +1,20 @@
 class SearchesController < ApplicationController
+  rescue_from Searches::ParseFailed do |error|
+    respond_to do |format|
+      format.html { render Searches::ShowView.new(pages: [], query: @raw_query) }
+      format.turbo_stream { render turbo_stream: turbo_stream.replace("search-results", plain: "No results") }
+    end
+  end
+
   def show
-    query = params[:query] || ""
-    pages = if query.present?
-      Page.search(query).limit(3)
+    @raw_query = params[:query] || ""
+    pages = if @raw_query.present?
+      query = Searches::Query.parse!(@raw_query)
+      Page.search(query.to_s).limit(3)
     else
-      Page.limit(3)
+      []
     end
 
-    render Searches::ShowView.new(pages:, query:)
+    render Searches::ShowView.new(pages:, query: @raw_query)
   end
 end

--- a/app/javascript/css/baseline.css
+++ b/app/javascript/css/baseline.css
@@ -621,6 +621,10 @@ figcaption {
   padding: 0;
 }
 
+mark {
+  background-color: aqua;
+}
+
 .dark {
   p {
     font-weight: 300;

--- a/app/javascript/css/components/combobox.css
+++ b/app/javascript/css/components/combobox.css
@@ -7,6 +7,6 @@
 
   & a:hover,
   & .selected {
-    background-color: var(--joy-button-secondary);
+    background-color: var(--joy-block-selected);
   }
 }

--- a/app/javascript/css/components/dialog.scss
+++ b/app/javascript/css/components/dialog.scss
@@ -1,6 +1,7 @@
 @import '../config/variables.scss';
 
 dialog {
+  color: var(--joy-text);
   width: 100%;
   border: none;
   animation: dialog-popup 0.25s ease-in-out;
@@ -25,6 +26,20 @@ dialog {
 
   input[type='search'] {
     border: 0;
+    color: var(--joy-text);
+  }
+}
+
+.dark {
+  & dialog {
+    border: 1px solid var(--joy-border-quiet);
+    background-color: var(--color-gray-950);
+
+    & input[type='search'] {
+      margin-left: 1rem;
+      background-color: var(--color-gray-800);
+      border: 1px solid var(--joy-border);
+    }
   }
 }
 

--- a/app/javascript/css/components/dialog.scss
+++ b/app/javascript/css/components/dialog.scss
@@ -25,7 +25,8 @@ dialog {
   }
 
   input[type='search'] {
-    border: 0;
+    border: none;
+    border-left: 1px solid var(--joy-border-quiet);
     color: var(--joy-text);
   }
 }

--- a/app/javascript/css/config/theme.css
+++ b/app/javascript/css/config/theme.css
@@ -76,6 +76,8 @@
   --joy-link-decoration: var(--joy-link-1);
   --joy-link-active: var(--joy-link-5);
 
+  --joy-block-selected: var(--joy-color-200);
+
   --joy-button-primary: var(--joy-color-600);
   --joy-button-primary-hover: var(--joy-color-700);
   --joy-button-primary-active: var(--joy-color-800);
@@ -126,6 +128,8 @@
   --joy-link-visited: var(--joy-link-3);
   --joy-link-decoration: var(--joy-link-8);
   --joy-link-active: var(--joy-link-5);
+
+  --joy-block-selected: var(--joy-color-900);
 
   --joy-button-transparent: none;
   --joy-button-transparent-hover: var(--joy-color-950);

--- a/app/javascript/css/layout.scss
+++ b/app/javascript/css/layout.scss
@@ -96,6 +96,10 @@ main > *,
   column-gap: var(--space-m);
 }
 
+.col-gap-xs {
+  column-gap: var(--space-xs);
+}
+
 .col-gap-3xs {
   column-gap: var(--space-3xs);
 }

--- a/app/javascript/css/utilities/tailwind.css
+++ b/app/javascript/css/utilities/tailwind.css
@@ -699,6 +699,10 @@
   padding-top: 4rem;
 }
 
+.pt-2 {
+  padding-top: 0.5rem;
+}
+
 .pt-4 {
   padding-top: 1rem;
 }

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -6,7 +6,19 @@ class Page < ApplicationRecord
   after_update_commit :update_in_search_index
   after_destroy_commit :remove_from_search_index
 
+  # The pages_search_index table is a full-text search index for the pages
+  # table. FTS5 tables contain a hidden 'rank' column that is (hand waving) a
+  # relevancy score for sorting search results.
+  # https://www.sqlite.org/fts5.html#sorting_by_auxiliary_function_results
+  #
   scope :ranked, -> { order(:rank) }
+
+  # snippet() is a SQLite function that returns a snippet of text containing the search term.
+  # It’s used to highlight search results. The snippet() function is not
+  # available in all databases, so this scope is only available for SQLite as
+  # part of the FTS5 extension.
+  # https://www.sqlite.org/fts5.html#the_snippet_function
+  #
   scope :with_snippets, ->(**options) do
     select("#{table_name}.*")
       .select("snippet(pages_search_index, 0, '<mark>', '</mark>', '…', 32) AS title_snippet")

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -10,7 +10,7 @@ class Page < ApplicationRecord
 
   def self.search(query)
     joins("JOIN pages_search_index ON pages.id = pages_search_index.page_id")
-      .where("pages_search_index MATCH ?", query.to_s.gsub(/\W/, " ") + "*")
+      .where("pages_search_index MATCH ?", query)
   end
 
   def title

--- a/app/models/searches.rb
+++ b/app/models/searches.rb
@@ -1,0 +1,4 @@
+module Searches
+  Error = Class.new(StandardError)
+  ParseFailed = Class.new(Error)
+end

--- a/app/models/searches/condition.rb
+++ b/app/models/searches/condition.rb
@@ -1,0 +1,15 @@
+module Searches
+  class Condition
+    attr_accessor :left, :operator, :right
+
+    def initialize(left, operator, right)
+      @left = left
+      @operator = operator
+      @right = right
+    end
+
+    def to_s
+      "#{left} #{operator} #{right}"
+    end
+  end
+end

--- a/app/models/searches/operator.rb
+++ b/app/models/searches/operator.rb
@@ -1,0 +1,28 @@
+module Searches
+  class Operator
+    def self.symbol(str)
+      case str
+      when "+"
+        :and
+      when "-"
+        :not
+      when "|"
+        :or
+      else
+        raise "Unknown operator: #{str}"
+      end
+    end
+
+    def initialize(operator)
+      @operator = self.class.symbol(operator)
+    end
+
+    def to_s
+      @operator.to_s.upcase
+    end
+
+    def to_sym
+      @operator.to_sym
+    end
+  end
+end

--- a/app/models/searches/phrase.rb
+++ b/app/models/searches/phrase.rb
@@ -1,13 +1,13 @@
 module Searches
   class Phrase
-    attr_accessor :phrase
+    attr_accessor :phrase # Array of strings
 
     def initialize(phrase)
       @phrase = phrase
     end
 
     def to_s
-      %("#{phrase}")
+      %("#{phrase.join(" ")}")
     end
   end
 end

--- a/app/models/searches/phrase.rb
+++ b/app/models/searches/phrase.rb
@@ -1,0 +1,13 @@
+module Searches
+  class Phrase
+    attr_accessor :phrase
+
+    def initialize(phrase)
+      @phrase = phrase
+    end
+
+    def to_s
+      %("#{phrase}")
+    end
+  end
+end

--- a/app/models/searches/query.rb
+++ b/app/models/searches/query.rb
@@ -21,7 +21,7 @@ module Searches
     end
 
     def to_s
-      expressions.map(&:to_s).join(" ") + "*"
+      expressions.map(&:to_s).join(" ")
     end
   end
 end

--- a/app/models/searches/query.rb
+++ b/app/models/searches/query.rb
@@ -2,12 +2,26 @@ module Searches
   class Query
     attr_accessor :expressions
 
+    def self.parse!(query)
+      ast = Searches::QueryParser.new.parse(query)
+
+      Searches::QueryTransformer.new.apply(ast)
+    rescue Parslet::ParseFailed => error
+      raise Searches::ParseFailed, error.message
+    end
+
+    def self.parse(query)
+      parse!(query)
+    rescue Searches::ParseFailed
+      nil
+    end
+
     def initialize(expressions)
       @expressions = expressions
     end
 
     def to_s
-      expressions(&:to_s).join(" ")
+      expressions.map(&:to_s).join(" ") + "*"
     end
   end
 end

--- a/app/models/searches/query.rb
+++ b/app/models/searches/query.rb
@@ -1,0 +1,13 @@
+module Searches
+  class Query
+    attr_accessor :expressions
+
+    def initialize(expressions)
+      @expressions = expressions
+    end
+
+    def to_s
+      expressions(&:to_s).join(" ")
+    end
+  end
+end

--- a/app/models/searches/query_parser.rb
+++ b/app/models/searches/query_parser.rb
@@ -2,6 +2,8 @@ module Searches
   class QueryParser < Parslet::Parser
     rule(:dquote) { str(%(")) }
     rule(:squote) { str(%(')) }
+    rule(:lparen) { str("(") }
+    rule(:rparen) { str(")") }
 
     rule(:space) { match('\s').repeat(1) }
     rule(:space?) { space.maybe }
@@ -17,9 +19,11 @@ module Searches
 
     rule(:condition) { (token.as(:left) >> operator >> expression.as(:right)).as(:condition) }
     rule(:token) { phrase | term }
-    rule(:expression) { condition | token }
+    rule(:expression) { (condition | token) }
 
-    rule(:query) { expression.repeat.as(:query) }
+    rule(:subexpression) { (lparen >> expression.as(:subexpression) >> rparen) }
+
+    rule(:query) { (expression | subexpression).repeat.as(:query) }
     root(:query)
   end
 end

--- a/app/models/searches/query_parser.rb
+++ b/app/models/searches/query_parser.rb
@@ -1,0 +1,23 @@
+module Searches
+  class QueryParser < Parslet::Parser
+    rule(:term) { match(%([^\s"'])).repeat(1).as(:term) }
+
+    rule(:clause) { (operator.maybe >> (phrase | term)).as(:clause) }
+    rule(:phrase) do
+      (
+        (squote >> (term >> space.maybe).repeat >> squote) |
+        (dquote >> (term >> space.maybe).repeat >> dquote)
+      ).as(:phrase)
+    end
+
+    rule(:dquote) { str(%(")) }
+    rule(:squote) { str(%(')) }
+    rule(:operator) { (str("+") | str("-")).as(:operator) }
+
+    rule(:space) { match('\s').repeat(1) }
+    rule(:space?) { space.maybe }
+
+    rule(:query) { (clause >> space?).repeat.as(:query) }
+    root(:query)
+  end
+end

--- a/app/models/searches/query_transformer.rb
+++ b/app/models/searches/query_transformer.rb
@@ -1,10 +1,11 @@
 module Searches
   class QueryTransformer < Parslet::Transform
     rule(term: simple(:term)) { Term.new(term.to_s) }
-    rule(phrase: sequence(:phrase)) { Phrase.new(phrase.join(" ")) }
+    rule(phrase: sequence(:phrase)) { Phrase.new(phrase) }
     rule(condition: {left: simple(:left), operator: simple(:operator), right: subtree(:right)}) do
       Condition.new(left, Operator.new(operator), right)
     end
+    rule(subexpression: simple(:expression)) { Subexpression.new(expression) }
     rule(query: sequence(:expressions)) { Searches::Query.new(expressions) }
   end
 end

--- a/app/models/searches/query_transformer.rb
+++ b/app/models/searches/query_transformer.rb
@@ -1,0 +1,10 @@
+module Searches
+  class QueryTransformer < Parslet::Transform
+    rule(term: simple(:term)) { Term.new(term.to_s) }
+    rule(phrase: sequence(:phrase)) { Phrase.new(phrase.join(" ")) }
+    rule(condition: {left: simple(:left), operator: simple(:operator), right: subtree(:right)}) do
+      Condition.new(left, Operator.new(operator), right)
+    end
+    rule(query: sequence(:expressions)) { Searches::Query.new(expressions) }
+  end
+end

--- a/app/models/searches/subexpression.rb
+++ b/app/models/searches/subexpression.rb
@@ -1,0 +1,13 @@
+module Searches
+  class Subexpression
+    attr_reader :expression
+
+    def initialize(expression)
+      @expression = expression
+    end
+
+    def to_s
+      "(#{expression})"
+    end
+  end
+end

--- a/app/models/searches/term.rb
+++ b/app/models/searches/term.rb
@@ -1,0 +1,13 @@
+module Searches
+  class Term
+    attr_accessor :term
+
+    def initialize(term)
+      @term = term
+    end
+
+    def to_s
+      @term.to_s
+    end
+  end
+end

--- a/app/views/searches/_help.html.mdrb
+++ b/app/views/searches/_help.html.mdrb
@@ -1,0 +1,41 @@
+Search the Joy of Rails archives.
+
+### Usage
+
+Type search text into the Search box above.
+
+On all other pages on the site, click the Search icon in the top nav or type `cmd+k` (macos) / `Windows+k` (windows) to open the Search dialog.
+
+![Screenshot of search dialog](https://github.com/user-attachments/assets/7ee482bf-3f56-4750-bf38-31832923bb65)
+
+### Syntax
+
+The Search input supports a bare text search:
+
+```sh:{"header":false}
+Ruby on Rails  # => Search for any of the three tokens
+```
+
+Quotes help group terms into phrases:
+
+```sh:{"header":false}
+"Ruby Rails" "Laravel PHP"  # => Search for any of the two phrases
+```
+
+The symbols `+`, `-`, and `|` are used to perform `AND`, `NOT`, and `OR` operations respectively with left-to-right precedence.
+
+```sh:{"header":false}
+Phlex + ERB # => Search must return both terms
+
+"Active Record" - "Action View" # => Search must only return the first of the two phrases
+
+Ruby + Rails | Hanami # => Search for "Ruby AND Rails" OR "Hanami"
+```
+
+Use parens to group conditions and change precedence:
+
+```sh:{"header":false}
+Ruby + (Rails | Hanami) # => Search for "Ruby AND Rails" OR "Ruby AND Hanami"
+```
+
+The search parsing and transformation logic is built on top of [Parslet](https://kschiess.github.io/parslet/get-started.html). The Parslet docs and [this blog post on query parsing](http://recursion.org/query-parser) provided helpful guidance.

--- a/app/views/searches/button.rb
+++ b/app/views/searches/button.rb
@@ -3,7 +3,7 @@ module Searches
     include PhlexConcerns::SvgTag
 
     def view_template
-      button(
+      a(
         id: "search-button",
         data: {
           controller: "modal-opener",
@@ -13,6 +13,7 @@ module Searches
         type: "button",
         class: ["button ghost focus:ring-gray-200 dark:focus:ring-gray-700 focus:ring-2 focus:outline-none"],
         aria_label: "Open Search Dialog",
+        href: "/search",
         role: "button"
       ) do
         svg_tag "icons/search.svg",

--- a/app/views/searches/combobox.rb
+++ b/app/views/searches/combobox.rb
@@ -65,16 +65,18 @@ module Searches
                 end
               end
             elsif query && query.length > 2
-              p(class: "pb-2") { "No results 😬" }
-              p(class: "pb-2 step--2") do
-                "Search function is new, bear with me 🧸."
-              end
-              p(class: "step--2") do
-                plain "Please"
-                whitespace
-                a(href: "/contact") { "reach out" }
-                whitespace
-                plain "if you’d like to see me address an unlisted topic."
+              div(class: "p-2") do
+                p(class: "pb-2") { "No results 😬" }
+                p(class: "pb-2 step--2") do
+                  "Search function is new, bear with me 🧸."
+                end
+                p(class: "step--2") do
+                  plain "Please"
+                  whitespace
+                  a(href: "/contact") { "reach out" }
+                  whitespace
+                  plain "if you’d like to see me address an unlisted topic."
+                end
               end
             end
           end

--- a/app/views/searches/combobox.rb
+++ b/app/views/searches/combobox.rb
@@ -59,7 +59,8 @@ module Searches
                       },
                       class: ["p-2", "block", ("selected" if i == 0)]
                     ) do
-                      page.title
+                      div { strong { raw safe(page.title_snippet) } }
+                      div(class: "text-sm") { raw safe(page.body_snippet) }
                     end
                   end
                 end

--- a/app/views/searches/combobox.rb
+++ b/app/views/searches/combobox.rb
@@ -28,7 +28,7 @@ module Searches
             autosubmit_delay_value: 300,
             turbo_frame: :search
           } do |f|
-          div(class: "flex items-center flex-row px-2") do
+          div(class: "flex items-center flex-row pl-2") do
             svg_tag "icons/search.svg", class: "w-[32px] fill-current text-theme"
             whitespace
             plain f.search_field :query,
@@ -59,7 +59,7 @@ module Searches
                       },
                       class: ["p-2", "block", ("selected" if i == 0)]
                     ) do
-                      div { strong { raw safe(page.title_snippet) } }
+                      div(class: "font-semibold") { raw safe(page.title_snippet) }
                       div(class: "text-sm") { raw safe(page.body_snippet) }
                     end
                   end

--- a/app/views/searches/combobox.rb
+++ b/app/views/searches/combobox.rb
@@ -28,7 +28,7 @@ module Searches
             autosubmit_delay_value: 300,
             turbo_frame: :search
           } do |f|
-          div(class: "flex items-center flex-row pl-2") do
+          div(class: "flex items-center flex-row pl-2 col-gap-xs") do
             svg_tag "icons/search.svg", class: "w-[32px] fill-current text-theme"
             whitespace
             plain f.search_field :query,
@@ -42,6 +42,7 @@ module Searches
               data: {
                 action: "autosubmit-form#submit"
               },
+              placeholder: "Search Joy of Rails",
               class: "w-full step-1"
           end
         end

--- a/app/views/searches/show_view.rb
+++ b/app/views/searches/show_view.rb
@@ -11,10 +11,12 @@ class Searches::ShowView < ApplicationView
   end
 
   def view_template
+    render Pages::Header.new(title: "Search")
     div(
       class: "section-content container py-gap mb-3xl"
     ) do
       render Searches::Combobox.new(pages:, query:)
+      render partial: "searches/help"
     end
   end
 end

--- a/app/views/users/header_navigations/show_view.rb
+++ b/app/views/users/header_navigations/show_view.rb
@@ -124,7 +124,7 @@ module Users
         div(class: "grid grid-gap rounded-lg joy-border-quiet") do
           div(class: "group relative flex items-center gap-x-6 p-4 leading-6 hover:bg-gray-50") do
             div(class: "flex-auto") do
-              p(class: "block font-semibold text-gray-900") do
+              p(class: "block font-semibold") do
                 plain current_user.name
               end
               p(class: "mt-1 text-gray-600") do

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,5 +56,7 @@ module Joy
     if ENV["RAILS_LOG_TO_STDOUT"] == "true"
       config.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new($stdout))
     end
+
+    config.active_support.to_time_preserves_timezone = :zone
   end
 end

--- a/config/initializers/new_framework_defaults_8_0.rb
+++ b/config/initializers/new_framework_defaults_8_0.rb
@@ -15,7 +15,7 @@
 # If set to `:offset`, `to_time` methods will use the UTC offset.
 # If `false`, `to_time` methods will convert to the local system UTC offset instead.
 #++
-Rails.application.config.active_support.to_time_preserves_timezone = :zone
+# Rails.application.config.active_support.to_time_preserves_timezone = :zone
 
 ###
 # When both `If-Modified-Since` and `If-None-Match` are provided by the client

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -22,12 +22,6 @@ RSpec.describe Page, type: :model do
       expect(Page.search("Joy of Rails")).to include page
     end
 
-    it "ignores special characters in the query" do
-      page = Page.find_or_create_by!(request_path: "/")
-
-      expect(Page.search("Joy\"&^ of Rails")).to include page
-    end
-
     it "works after rebuilding index" do
       page = Page.find_or_create_by!(request_path: "/")
 

--- a/spec/models/searches/query_parser_spec.rb
+++ b/spec/models/searches/query_parser_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe Searches::QueryParser do
+  subject(:parser) { described_class.new }
+
+  it "can parse a simple query" do
+    parse_tree = parser.parse("hello parslet")
+
+    expect(parse_tree[:query]).to match([
+      {clause: {term: kind_of(Parslet::Slice)}},
+      {clause: {term: kind_of(Parslet::Slice)}}
+    ])
+  end
+
+  it "ignores punctuation characters" do
+    parse_tree = parser.parse("hello, parslet")
+
+    expect(parse_tree[:query]).to match([
+      {clause: {term: kind_of(Parslet::Slice)}},
+      {clause: {term: kind_of(Parslet::Slice)}}
+    ])
+  end
+
+  it "parses boolean operators" do
+    expect(parser.parse("the +cat in the -hat")[:query]).to match([
+      {clause: {term: kind_of(Parslet::Slice)}},
+      {clause: {operator: kind_of(Parslet::Slice), term: kind_of(Parslet::Slice)}},
+      {clause: {term: kind_of(Parslet::Slice)}},
+      {clause: {term: kind_of(Parslet::Slice)}},
+      {clause: {operator: kind_of(Parslet::Slice), term: kind_of(Parslet::Slice)}}
+    ])
+  end
+
+  it "parses phrases" do
+    expect(parser.parse(%("cat in the hat" -green +ham))[:query]).to match([
+      {clause: {phrase: [
+        {term: kind_of(Parslet::Slice)},
+        {term: kind_of(Parslet::Slice)},
+        {term: kind_of(Parslet::Slice)},
+        {term: kind_of(Parslet::Slice)}
+      ]}},
+      {clause: {operator: kind_of(Parslet::Slice), term: kind_of(Parslet::Slice)}},
+      {clause: {operator: kind_of(Parslet::Slice), term: kind_of(Parslet::Slice)}}
+    ])
+  end
+
+  it "parses phrases" do
+    expect(parser.parse(%('cat in the hat' -green +ham))[:query]).to match([
+      {clause: {phrase: [
+        {term: kind_of(Parslet::Slice)},
+        {term: kind_of(Parslet::Slice)},
+        {term: kind_of(Parslet::Slice)},
+        {term: kind_of(Parslet::Slice)}
+      ]}},
+      {clause: {operator: kind_of(Parslet::Slice), term: kind_of(Parslet::Slice)}},
+      {clause: {operator: kind_of(Parslet::Slice), term: kind_of(Parslet::Slice)}}
+    ])
+  end
+end

--- a/spec/models/searches/query_parser_spec.rb
+++ b/spec/models/searches/query_parser_spec.rb
@@ -71,4 +71,19 @@ RSpec.describe Searches::QueryParser do
       )
     ])
   end
+
+  it "parses a subexpression" do
+    expect(parse_query("the (cat | hat)")[:query]).to match([
+      hash_including(:term),
+      hash_including(
+        subexpression: hash_including(
+          condition: hash_including(
+            :operator,
+            left: hash_including(:term),
+            right: hash_including(:term)
+          )
+        )
+      )
+    ])
+  end
 end

--- a/spec/models/searches/query_transformer_spec.rb
+++ b/spec/models/searches/query_transformer_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Searches::QueryTransformer do
+  subject(:transformer) { described_class.new }
+  let(:parser) { Searches::QueryParser.new }
+
+  it "transforms a simple query" do
+    ast = parser.parse("hello parslet")
+    query = transformer.apply(ast)
+
+    expect(query.to_s).to eq("hello parslet")
+  end
+
+  it "transforms a query with boolean operators" do
+    ast = parser.parse(%(the + cat))
+
+    query = transformer.apply(ast)
+
+    expect(query.to_s).to eq("the AND cat")
+  end
+
+  it "transforms a query with boolean operators and phrase at the start" do
+    ast = parser.parse(%(the + cat | "the hat"))
+
+    query = transformer.apply(ast)
+
+    expect(query.to_s).to eq(%(the AND cat OR "the hat"))
+  end
+
+  it "parses a query with boolean operators and phrase at the end" do
+    ast = parser.parse(%("cat in the hat" -green +ham))
+
+    query = transformer.apply(ast)
+
+    expect(query.to_s).to eq(%("cat in the hat" NOT green AND ham))
+  end
+end

--- a/spec/models/searches/query_transformer_spec.rb
+++ b/spec/models/searches/query_transformer_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Searches::QueryTransformer do
     query = transformer.apply(ast)
 
     expect(query.to_s).to eq("hello parslet")
+
+    expect { Page.search(query.to_s) }.not_to raise_error
   end
 
   it "transforms a query with boolean operators" do
@@ -17,6 +19,8 @@ RSpec.describe Searches::QueryTransformer do
     query = transformer.apply(ast)
 
     expect(query.to_s).to eq("the AND cat")
+
+    expect { Page.search(query.to_s) }.not_to raise_error
   end
 
   it "transforms a query with boolean operators and phrase at the start" do
@@ -25,6 +29,8 @@ RSpec.describe Searches::QueryTransformer do
     query = transformer.apply(ast)
 
     expect(query.to_s).to eq(%(the AND cat OR "the hat"))
+
+    expect { Page.search(query.to_s) }.not_to raise_error
   end
 
   it "parses a query with boolean operators and phrase at the end" do
@@ -33,5 +39,27 @@ RSpec.describe Searches::QueryTransformer do
     query = transformer.apply(ast)
 
     expect(query.to_s).to eq(%("cat in the hat" NOT green AND ham))
+
+    expect { Page.search(query.to_s) }.not_to raise_error
+  end
+
+  it "parses a query with a subexpression" do
+    ast = parser.parse("the (cat | hat)")
+
+    query = transformer.apply(ast)
+
+    expect(query.to_s).to eq("the (cat OR hat)")
+
+    expect { Page.search(query.to_s) }.not_to raise_error
+  end
+
+  it "parses a query with a subexpression" do
+    ast = parser.parse("the (cat | hat)")
+
+    query = transformer.apply(ast)
+
+    expect(query.to_s).to eq("the (cat OR hat)")
+
+    expect { Page.search(query.to_s) }.not_to raise_error
   end
 end

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Searches", type: :request do
 
       expect(response).to have_http_status(:success)
 
-      expect(page).to have_content("Progressive Web Apps on Rails Showcase")
+      expect(page).not_to have_content("No results")
     end
 
     it "renders the search results with query" do
@@ -38,6 +38,19 @@ RSpec.describe "Searches", type: :request do
 
       expect(page).to have_content("Progressive Web Apps on Rails Showcase")
       expect(page).not_to have_content("Introducing Joy of Rails")
+    end
+
+    it "doesn’t blow up with invalid query" do
+      get search_path, params: {query: "(((("}
+
+      expect(response).to have_http_status(:success)
+      expect(page).to have_content("No results")
+    end
+
+    it "doesn’t blow up with invalid query as turbo stream" do
+      get search_path, params: {query: "(((("}, as: :turbo_stream
+
+      expect(response).to have_http_status(:success)
     end
   end
 end


### PR DESCRIPTION
So I went and wrote a search query parser for the new search dialog.

![image](https://github.com/user-attachments/assets/7ee482bf-3f56-4750-bf38-31832923bb65)

The goal is to help constrain the full text search features available to the user and to catch syntax errors before they get to SQLite.

The parser supports a bare text search:

```
Progressive Web Ap  # => Search for any of the three tokens
```

Quotes help group terms into phrases

```
"Ruby Rails" "Laravel PHP"  # => Search for any of the two phrases
```

The symbols `+`, `-`, and `|` are used to perform `AND`, `NOT`, and `OR` operations respectively with left-to-right precedence.

```
Phlex + ERB # => Search must return both terms

"Active Record" - "Action View" # => Search must only return the first of the two phrases

Ruby + Rails | Hanami # => Search for "Ruby AND Rails" OR "Hanami"
```

Use parens to group conditions and change precedence
```
Ruby + (Rails | Hanami) # => Search for "Ruby AND Rails" OR "Ruby AND Hanami"
```

The search parsing and transformation logic is built on top of [Parslet](https://kschiess.github.io/parslet/get-started.html). The Parslet docs and [this blog post on query parsing](http://recursion.org/query-parser) provided helpful guidance.