### PR TITLE
Enhance search index

### DIFF
--- a/app/jobs/pages/search_index_refresh_job.rb
+++ b/app/jobs/pages/search_index_refresh_job.rb
@@ -1,0 +1,7 @@
+module Pages
+  class SearchIndexRefreshJob < ApplicationJob
+    def perform
+      Page.refresh_search_index
+    end
+  end
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -30,7 +30,7 @@ class Page < ApplicationRecord
       .where("pages_search_index MATCH ?", query)
   end
 
-  def self.rebuild_search_index
+  def self.refresh_search_index
     find_each(&:update_in_search_index)
   end
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -43,7 +43,15 @@ class Page < ApplicationRecord
   end
 
   def body_html
-    ApplicationController.render(inline: body, type: resource.handler, layout: false)
+    ApplicationController.render(
+      inline: body,
+      type: (resource.handler.to_sym == :mdrb) ? :"mdrb-atom" : resource.handler,
+      layout: false,
+      content_type: "application/atom+xml",
+      assigns: {
+        format: :atom
+      }
+    )
   end
 
   def body_text

--- a/app/views/components/markdown/application.rb
+++ b/app/views/components/markdown/application.rb
@@ -12,11 +12,13 @@ class Markdown::Application < Markdown::Base
     }
   end
 
-  def code_block(source, language = "", **attributes)
+  def code_block(source, metadata = "", **attributes)
+    language, _ = metadata.split(":", 2)
     render CodeBlock::Code.new(source, language: language, **attributes)
   end
 
   def image(src, alt: "", title: "")
+    title, _ = title.split("|", 2)
     figure do
       image_tag(src, alt: alt, title: title)
       figcaption { title }

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -1,0 +1,6 @@
+namespace :deploy do
+  desc "Post deploy script"
+  task finish: :environment do
+    Pages::SearchIndexRefreshJob.perform_later
+  end
+end

--- a/spec/jobs/pages/search_index_refresh_job_spec.rb
+++ b/spec/jobs/pages/search_index_refresh_job_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Pages::SearchIndexRefreshJob, type: :job do
+  it "refreshes the search index" do
+    allow(Page).to receive(:refresh_search_index)
+
+    described_class.perform_now
+
+    expect(Page).to have_received(:refresh_search_index)
+  end
+end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Page, type: :model do
     expect(page.resource).to eq Sitepress.site.get("/")
   end
 
-  describe ".rebuild_search_index" do
+  describe ".refresh_search_index" do
     it "doesn’t blow up" do
       Page.find_or_create_by!(request_path: "/")
 
-      Page.rebuild_search_index
+      Page.refresh_search_index
     end
   end
 
@@ -25,7 +25,7 @@ RSpec.describe Page, type: :model do
     it "works after rebuilding index" do
       page = Page.find_or_create_by!(request_path: "/")
 
-      Page.rebuild_search_index
+      Page.refresh_search_index
 
       expect(Page.search("Joy of Rails")).to include page
     end


### PR DESCRIPTION
* Refresh search index on deploy with `bin/rails deploy:finish` (hooked up to Hatchbox to run as post-deploy script)
* Adds job for refreshing search index async
* Change search index content rendering to use same as atom feed. This will help remove screen reader text and metadata from the search index which can now show in the UX with snippets.