### PR TITLE
Update activestorage settings

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,8 +37,8 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # Store uploaded files on digitalocean (see config/storage.yml for options).
+  config.active_storage.service = :digitalocean
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
Use digital ocean for activestorage in prod. Encrypted credentials already contain the desired configuration.