### PR TITLE
Lint rubocop debugger

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,5 @@
 require:
   - standard
-  # TODO: Add cops later
-  # - rubocop-rails
-  # - rubocop-rspec
 
 inherit_gem:
   standard: config/base.yml
@@ -15,3 +12,4 @@ AllCops:
     - '.git/**/*'
     - 'build/**/*'
     - 'rubies/**/*'
+  SuggestExtensions: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,8 @@ AllCops:
     - 'build/**/*'
     - 'rubies/**/*'
   SuggestExtensions: false
+
+Lint/Debugger:
+  Enabled: true
+  DebuggerRequires:
+    - debug

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SearchesController < ApplicationController
   rescue_from Searches::ParseFailed do |error|
     respond_to do |format|


### PR DESCRIPTION
The previous deploy was bad because a `require "debug"` statement made it into app code. Rubocop can now catch this oversight.
