### PR TITLE
Topic nav shows active current page

### DIFF
--- a/app/javascript/controllers/current-page.js
+++ b/app/javascript/controllers/current-page.js
@@ -1,0 +1,51 @@
+import { Controller } from '@hotwired/stimulus';
+
+import { debug } from '../utils';
+
+const console = debug('app:javascript:controllers:current-page');
+
+export default class extends Controller {
+  connect() {
+    console.log('Connected');
+
+    this.updateActiveLink();
+    this.updateSelectedOption();
+    this.updateActiveLink = this.updateActiveLink.bind(this);
+
+    window.addEventListener('turbo:before-render', this.updateActiveLink);
+    window.addEventListener('turbo:before-frame-render', this.updateActiveLink);
+  }
+
+  disconnect() {
+    window.removeEventListener('turbo:before-render', this.updateActiveLink);
+    window.removeEventListener(
+      'turbo:before-frame-render',
+      this.updateActiveLink,
+    );
+  }
+
+  updateActiveLink(event) {
+    console.log('updateActiveLink');
+    this.element.querySelectorAll('a').forEach((link) => {
+      if (link.getAttribute('href') === this.currentUrl) {
+        link.classList.add('active');
+        link.closest('li').classList.add('active');
+      } else {
+        link.classList.remove('active');
+        link.closest('li').classList.remove('active');
+      }
+    });
+  }
+
+  updateSelectedOption() {
+    this.element.querySelectorAll('option').forEach((option) => {
+      if (option.getAttribute('value') === this.currentUrl) {
+        option.selected = true;
+      }
+    });
+  }
+
+  get currentUrl() {
+    return window.location.pathname;
+  }
+}

--- a/app/javascript/controllers/current-page.js
+++ b/app/javascript/controllers/current-page.js
@@ -8,23 +8,19 @@ export default class extends Controller {
   connect() {
     console.log('Connected');
 
-    this.updateActiveLink();
-    this.updateSelectedOption();
-    this.updateActiveLink = this.updateActiveLink.bind(this);
+    this.updateActive();
+    this.updateActive = this.updateActive.bind(this);
 
-    window.addEventListener('turbo:before-render', this.updateActiveLink);
-    window.addEventListener('turbo:before-frame-render', this.updateActiveLink);
+    window.addEventListener('turbo:before-render', this.updateActive);
+    window.addEventListener('turbo:before-frame-render', this.updateActive);
   }
 
   disconnect() {
-    window.removeEventListener('turbo:before-render', this.updateActiveLink);
-    window.removeEventListener(
-      'turbo:before-frame-render',
-      this.updateActiveLink,
-    );
+    window.removeEventListener('turbo:before-render', this.updateActive);
+    window.removeEventListener('turbo:before-frame-render', this.updateActive);
   }
 
-  updateActiveLink(event) {
+  updateActive(event) {
     console.log('updateActiveLink');
     this.element.querySelectorAll('a').forEach((link) => {
       if (link.getAttribute('href') === this.currentUrl) {
@@ -35,9 +31,7 @@ export default class extends Controller {
         link.closest('li').classList.remove('active');
       }
     });
-  }
 
-  updateSelectedOption() {
     this.element.querySelectorAll('option').forEach((option) => {
       if (option.getAttribute('value') === this.currentUrl) {
         option.selected = true;

--- a/app/javascript/controllers/current-page.js
+++ b/app/javascript/controllers/current-page.js
@@ -11,13 +11,16 @@ export default class extends Controller {
     this.updateActive();
     this.updateActive = this.updateActive.bind(this);
 
-    window.addEventListener('turbo:before-render', this.updateActive);
-    window.addEventListener('turbo:before-frame-render', this.updateActive);
+    document.addEventListener('turbo:before-render', this.updateActive);
+    document.addEventListener('turbo:before-frame-render', this.updateActive);
   }
 
   disconnect() {
-    window.removeEventListener('turbo:before-render', this.updateActive);
-    window.removeEventListener('turbo:before-frame-render', this.updateActive);
+    document.removeEventListener('turbo:before-render', this.updateActive);
+    document.removeEventListener(
+      'turbo:before-frame-render',
+      this.updateActive,
+    );
   }
 
   updateActive(event) {

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -5,6 +5,7 @@
 import { application } from './application';
 
 import ClipboardCopy from './clipboard-copy';
+import CurrentPage from './current-page';
 import Darkmode from './darkmode';
 import Flash from './flash';
 import ModalOpener from './modal-opener';
@@ -31,16 +32,19 @@ import SnippetTweet from './snippets/tweet';
 import SearchCombobox from './searches/combobox';
 import SearchListbox from './searches/listbox';
 
-application.register('modal-opener', ModalOpener);
-application.register('analytics', AnalyticsCustomEvent);
 application.register('clipboard-copy', ClipboardCopy);
+application.register('current-page', CurrentPage);
 application.register('darkmode', Darkmode);
 application.register('flash', Flash);
+application.register('modal-opener', ModalOpener);
+
 application.register('dialog', Dialog);
 
 application.register('pwa-installation', PwaInstallation);
 application.register('pwa-web-push-subscription', PwaWebPushSubscription);
 application.register('pwa-web-push-demo', PwaWebPushDemo);
+
+application.register('analytics', AnalyticsCustomEvent);
 application.register('table-of-contents', TableOfContents);
 
 application.register('frame-form', FrameForm);

--- a/app/javascript/css/application.css
+++ b/app/javascript/css/application.css
@@ -30,6 +30,7 @@
 @import './components/site-header.css';
 @import './components/main-content.css';
 @import './components/article-content.css';
+@import './components/column-content.css';
 @import './components/footer.scss';
 @import './components/footer.css';
 @import './components/newsletter-banner.css';

--- a/app/javascript/css/components/article-content.css
+++ b/app/javascript/css/components/article-content.css
@@ -131,9 +131,3 @@
     padding-inline-start: var(--space-s);
   }
 }
-
-.column-content {
-  & li:has(+ li) {
-    margin-bottom: var(--space-xs);
-  }
-}

--- a/app/javascript/css/components/column-content.css
+++ b/app/javascript/css/components/column-content.css
@@ -1,0 +1,5 @@
+.column-content {
+  & li.active {
+    background-color: var(--joy-background-header);
+  }
+}

--- a/app/javascript/css/config/theme.css
+++ b/app/javascript/css/config/theme.css
@@ -45,6 +45,7 @@
   --joy-background-banner: var(--joy-color-100);
   --joy-background-footer: var(--joy-color-200);
   --joy-background-blockquote: var(--joy-color-100);
+  --joy-background-active: var(--joy-color-200);
 
   --joy-background-mask: var(--color-darken);
   --joy-background-reset: white;
@@ -103,6 +104,7 @@
   --joy-background-banner: var(--color-slate-900);
   --joy-background-footer: var(--color-slate-800);
   --joy-background-blockquote: var(--color-slate-800);
+  --joy-background-active: var(--color-slate-800);
 
   --joy-background-mask: var(--color-lighten);
   --joy-background-reset: var(--color-slate-950);

--- a/app/javascript/css/utilities/custom.css
+++ b/app/javascript/css/utilities/custom.css
@@ -2,6 +2,10 @@
   margin-bottom: var(--grid-gutter);
 }
 
+.mb-xs {
+  margin-bottom: var(--space-xs);
+}
+
 .mb-xl {
   margin-bottom: var(--space-xl);
 }

--- a/app/javascript/css/utilities/tailwind.css
+++ b/app/javascript/css/utilities/tailwind.css
@@ -590,6 +590,10 @@
   fill: var(--joy-text);
 }
 
+.p-1 {
+  padding: 0.25rem;
+}
+
 .p-2 {
   padding: 0.5rem;
 }

--- a/app/views/topics/nav.rb
+++ b/app/views/topics/nav.rb
@@ -24,7 +24,7 @@ module Topics
         select(
           name: "topic",
           data: {
-            :controller => "select-nav",
+            :controller => "select-nav current-page",
             :action => "select-nav#visit",
             "select-nav-turbo-frame-value" => "topics-mainbar"
           }
@@ -43,20 +43,27 @@ module Topics
     end
 
     def topics_list
-      topics.each do |topic|
-        div id: dom_id(topic), class: "text-small mb-2 hidden lg:block" do
-          a(
-            href: topic_path(topic),
-            data: {
-              turbo_frame: "topics-mainbar"
-            }
+      ul(data: {controller: "current-page"}) do
+        topics.each do |topic|
+          li(
+            id: dom_id(topic),
+            class: [
+              "text-small p-1 hidden lg:block"
+            ]
           ) do
-            topic.name
-          end
+            a(
+              href: topic_path(topic),
+              data: {
+                turbo_frame: "topics-mainbar"
+              }
+            ) do
+              topic.name
+            end
 
-          whitespace
-          span(class: "text-faint") do
-            plain "(#{topic.pages_count})"
+            whitespace
+            span(class: "text-faint") do
+              plain "(#{topic.pages_count})"
+            end
           end
         end
       end

--- a/app/views/topics/nav.rb
+++ b/app/views/topics/nav.rb
@@ -2,6 +2,7 @@ module Topics
   class Nav < ApplicationComponent
     include Phlex::Rails::Helpers::CurrentPage
     include Phlex::Rails::Helpers::DOMID
+    include Phlex::Rails::Helpers::Request
     include PhlexConcerns::FlexBlock
 
     attr_reader :topics, :attributes
@@ -33,7 +34,7 @@ module Topics
           topics.each do |topic|
             option(
               value: topic_path(topic),
-              selected: current_page?(topic_path(topic))
+              selected: request&.path == topic_path(topic)
             ) do
               topic.name
             end

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -20,7 +20,7 @@
         <h3 class="mb-8 hidden lg:block"><%= topic.name %></h3>
         <ul>
           <% topic.pages.as_published_articles.each do |page| %>
-            <%= tag.li id: dom_id(page) do %>
+            <%= tag.li id: dom_id(page), class: "mb-xs" do %>
               <%= render Pages::Info.new(
                     title: page.title,
                     request_path: page.request_path,


### PR DESCRIPTION
When interacting with the Topics nav, the current topic should show as active/selected. For the desktop nav, we highlight the nav link background. The topic select nav should show the matching select option. 


![Screenshot 2024-11-14 at 1 53 09 PM](https://github.com/user-attachments/assets/032b30da-ed21-43f2-9813-6160873dc839)

![Screenshot 2024-11-14 at 1 53 34 PM](https://github.com/user-attachments/assets/b8745d7d-6806-42a9-9b02-099751d49e71)

Implementation is handled with a Stimulus controller that hangs an event listener on document for Turbo "before render" events.