### PR TITLE
Enhance vector queries

### DIFF
--- a/app/content/layouts/article.html.erb
+++ b/app/content/layouts/article.html.erb
@@ -29,7 +29,7 @@
         <%= render Pages::Topics.new(topics: topics) %>
       <% end %>
       <% cache [@page, :related_pages] do %>
-        <% related_pages = @page.related_pages.limit(3) %>
+        <% related_pages = @page.related_pages.published.limit(3) %>
         <% if related_pages.present? %>
           <h3>More articles to enjoy</h3>
           <ul class="list-none">

--- a/app/content/layouts/article.html.erb
+++ b/app/content/layouts/article.html.erb
@@ -28,12 +28,12 @@
       <% if topics.present? %>
         <%= render Pages::Topics.new(topics: topics) %>
       <% end %>
-      <% cache [@page, :related_articles] do %>
-        <% related_articles = @page.related_articles.limit(3) %>
-        <% if related_articles.present? %>
+      <% cache [@page, :related_pages] do %>
+        <% related_pages = @page.related_pages.limit(3) %>
+        <% if related_pages.present? %>
           <h3>More articles to enjoy</h3>
           <ul class="list-none">
-            <% related_articles.each do |page| %>
+            <% related_pages.each do |page| %>
               <%= tag.li id: dom_id(page), class: "mb-xs" do %>
                 <%= render Pages::Info.new(
                       title: page.title,

--- a/app/models/page/similarity.rb
+++ b/app/models/page/similarity.rb
@@ -5,19 +5,42 @@ class Page
     included do
       has_one :page_embedding, inverse_of: :page, foreign_key: :id, primary_key: :id
 
+      # We unscope(:where) because we want to disable the default association
+      # behavior of scoping where(id: page.id) for querying related pages not
+      # including the page itself.
+      #
+      has_many :related_pages,
+        ->(page) { unscope(:where).similar_to(page) },
+        class_name: "Page", foreign_key: :id, primary_key: :id
+
+      # Here’s an exciting query. This is how we find related pages using the
+      # PageEmbedding virtual table with the sqlite-vec extension.
+      #
+      # We’re using a subquery to find the embeddings that match the embedding
+      # of the given page. We then join the pages table to the subquery to get
+      # the related pages. We order by the distance between the embeddings and
+      # exclude the page itself.
+      #
+      # We use the associated scope to ensure that the page_embedding
+      # association exists when querying the related pages, otherwise, the MATCH
+      # embedding subquery will raise an ActiveRecord::StatementInvalid error;
+      # there needs to be an embedding to match against!
+      #
       scope :similar_to, ->(page) do
-        select("pages.*")
+        similar_page_subquery = PageEmbedding
+          .where("embedding MATCH (?)", PageEmbedding.select(:embedding).where(id: page.id))
+          .select(:id, :distance)
+          .order(distance: :asc)
+          .limit(10)
+
+        where.associated(:page_embedding)
+          .select("pages.*")
           .select("similar_pages.distance")
-          .from("(#{PageEmbedding.similar_to(page.page_embedding).to_sql}) similar_pages")
+          .from("(#{similar_page_subquery.to_sql}) similar_pages")
           .joins("LEFT JOIN pages ON similar_pages.id = pages.id")
           .where("similar_pages.id != ?", page.id)
           .order("similar_pages.distance ASC")
       end
-    end
-
-    def related_articles
-      return self.class.none unless page_embedding
-      self.class.similar_to(self)
     end
   end
 end

--- a/app/models/page/similarity.rb
+++ b/app/models/page/similarity.rb
@@ -21,23 +21,23 @@ class Page
       # the related pages. We order by the distance between the embeddings and
       # exclude the page itself.
       #
-      # We use the associated scope to ensure that the page_embedding
-      # association exists when querying the related pages, otherwise, the MATCH
-      # embedding subquery will raise an ActiveRecord::StatementInvalid error;
-      # there needs to be an embedding to match against!
+      # There may be a better way to handle this, but we have an extra query to
+      # make sure the given page has an associated page_embedding, otherwise the
+      # embedding MATCH subquery will fail with an invalid statement error.
       #
       scope :similar_to, ->(page) do
+        return none unless page.page_embedding
+
         similar_page_subquery = PageEmbedding
           .where("embedding MATCH (?)", PageEmbedding.select(:embedding).where(id: page.id))
           .select(:id, :distance)
           .order(distance: :asc)
           .limit(10)
 
-        where.associated(:page_embedding)
-          .select("pages.*")
+        select("pages.*")
           .select("similar_pages.distance")
           .from("(#{similar_page_subquery.to_sql}) similar_pages")
-          .joins("LEFT JOIN pages ON similar_pages.id = pages.id")
+          .joins("INNER JOIN pages ON similar_pages.id = pages.id")
           .where("similar_pages.id != ?", page.id)
           .order("similar_pages.distance ASC")
       end

--- a/app/models/page_embedding.rb
+++ b/app/models/page_embedding.rb
@@ -7,13 +7,6 @@ class PageEmbedding < ApplicationRecord
 
   belongs_to :page, inverse_of: :page_embedding, foreign_key: :id, primary_key: :id, touch: true
 
-  scope :similar_to, ->(page_embedding, limit: 11) {
-    select("id, distance")
-      .where("embedding MATCH ?", page_embedding.embedding.to_s)
-      .where("k = ?", limit)
-      .order(distance: :asc)
-  }
-
   # SQLite supports upserts via INSERT ON CONFLICT DO UPDATE for normal tables
   # but not for virtual tables. This method behaves like an upsert the embedding
   # for a page by first removing the existing embedding if it exists and then

--- a/app/models/page_embedding.rb
+++ b/app/models/page_embedding.rb
@@ -14,13 +14,6 @@ class PageEmbedding < ApplicationRecord
       .order(distance: :asc)
   }
 
-  def self.custom_create(id:, embedding:)
-    connection.execute sanitize_sql([<<~SQL.squish, id, embedding.to_s])
-      INSERT INTO page_embeddings (id, embedding)
-      VALUES (?, ?)
-    SQL
-  end
-
   # SQLite supports upserts via INSERT ON CONFLICT DO UPDATE for normal tables
   # but not for virtual tables. This method behaves like an upsert the embedding
   # for a page by first removing the existing embedding if it exists and then
@@ -28,7 +21,7 @@ class PageEmbedding < ApplicationRecord
   def self.upsert_embedding!(page, embedding)
     transaction do
       page.page_embedding&.destroy
-      custom_create(id: page.id, embedding: embedding)
+      create(id: page.id, embedding: embedding)
     end
   end
 

--- a/app/models/types/vector.rb
+++ b/app/models/types/vector.rb
@@ -1,7 +1,9 @@
 # Custom type for ActiveRecord to deserialize vectors from vector columns
 # enabled by sqlite-vec extensions which provides vec0 virtual tables.
 module Types
-  class Vector < ActiveRecord::Type::Json
+  class Vector < ActiveModel::Type::Value
+    include ActiveModel::Type::SerializeCastValue
+
     def type
       :vector
     end
@@ -9,11 +11,25 @@ module Types
     def deserialize(value)
       return value unless value.is_a?(::String)
 
-      begin
-        value.unpack("F*")
-      rescue
-        nil
+      # When we initially created the vector column, we serialized the vector as JSON
+      if value.start_with?("[")
+        ActiveSupport::JSON.decode(value)
+      else
+        # Unpacks a float array from the binary string as represented in the
+        # database. The format is "f*" per sqlite-vec docs. The "f*" template is
+        # a "single-precision float directive" per Ruby docs
+        # https://docs.ruby-lang.org/en/3.3/packed_data_rdoc.html
+        #
+        # There are minor precision issues when unpacking the binary string so
+        # we prefer to use subqueries for embedding MATCH comparision over
+        # deserializing/serialize in ActiveRecord.
+        #
+        value.unpack("f*")
       end
+    end
+
+    def serialize(value)
+      ActiveSupport::JSON.encode(value) unless value.nil?
     end
   end
 end

--- a/spec/factories/page_embeddings.rb
+++ b/spec/factories/page_embeddings.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  sequence(:random_embedding) do
+    Array.new(PageEmbedding::OPENAI_EMBEDDING_LENGTH) { rand(-0.1..0.1) }
+  end
+
+  factory :page_embedding do
+    id { SecureRandom.uuid_v7 }
+    embedding { generate(:random_embedding) }
+  end
+end

--- a/spec/jobs/pages/batch_embedding_job_spec.rb
+++ b/spec/jobs/pages/batch_embedding_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Pages::BatchEmbeddingJob, type: :job do
 
   it "doesn’t blow up when page has embedding" do
     page = FactoryBot.create(:page, :published)
-    PageEmbedding.custom_create(id: page.id, embedding: PageEmbedding.random)
+    FactoryBot.create(:page_embedding, id: page.id)
 
     expect(Pages::EmbeddingJob).not_to receive(:perform_later)
 

--- a/spec/models/page/similarity_spec.rb
+++ b/spec/models/page/similarity_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe Page::Similarity, type: :model do
       end
 
       expect(article.reload.related_pages).to include similar
+
+      # works with additional scope
+      expect(article.reload.related_pages.published).to include similar
     end
 
     it "returns empty when no embedding is calculated" do

--- a/spec/models/page/similarity_spec.rb
+++ b/spec/models/page/similarity_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Page::Similarity, type: :model do
-  describe "#related_articles" do
+  describe "#related_pages" do
     it "finds related articles" do
       article = FactoryBot.create(:page, :published, request_path: "/articles/web-push-notifications-from-rails")
       similar = FactoryBot.create(:page, :published, request_path: "/articles/add-your-rails-app-to-the-home-screen")
@@ -12,13 +12,13 @@ RSpec.describe Page::Similarity, type: :model do
         PageEmbedding.upsert_embedding!(page, embeddings_yaml[page.request_path])
       end
 
-      expect(article.reload.related_articles).to include similar
+      expect(article.reload.related_pages).to include similar
     end
 
     it "returns empty when no embedding is calculated" do
       article = FactoryBot.create(:page, :published, request_path: "/articles/web-push-notifications-from-rails")
 
-      expect(article.related_articles.to_a).to be_empty
+      expect(article.related_pages).to be_empty
     end
   end
 end

--- a/spec/models/page_embedding_spec.rb
+++ b/spec/models/page_embedding_spec.rb
@@ -4,4 +4,50 @@ RSpec.describe PageEmbedding, type: :model do
   it "declared openai embedding length" do
     expect(described_class::OPENAI_EMBEDDING_LENGTH).to eq(1536)
   end
+
+  it "serializes and deserializes embedding vector" do
+    embedding = FactoryBot.generate(:random_embedding)
+    page = FactoryBot.create(:page)
+
+    page_embedding = PageEmbedding.create!(id: page.id, embedding: embedding)
+
+    expect(page_embedding.embedding).to eq(embedding)
+
+    page_embedding.reload
+
+    expect(page_embedding.embedding.length).to eq(embedding.length)
+
+    # We don't want to compare exact values because of floating point precision
+    # issues. Instead, we'll compare the first few values because it’s good
+    # enough.
+    page_embedding.embedding.take(5).zip(embedding.take(5)).each do |actual, expected|
+      expect(actual).to be_within(0.01).of(expected)
+    end
+  end
+
+  it "upserts embedding for a page" do
+    page = FactoryBot.create(:page)
+
+    random_embedding_1 = FactoryBot.generate(:random_embedding)
+
+    page_embedding_1 = PageEmbedding.upsert_embedding!(page, random_embedding_1)
+
+    expect(page_embedding_1.embedding.length).to eq(random_embedding_1.length)
+    page_embedding_1.embedding.take(5).zip(random_embedding_1.take(5)).each do |actual, expected|
+      expect(actual).to be_within(0.01).of(expected)
+    end
+
+    page.reload
+
+    random_embedding_2 = FactoryBot.generate(:random_embedding)
+
+    page_embedding_2 = PageEmbedding.upsert_embedding!(page, random_embedding_2)
+
+    expect(page_embedding_2.embedding.length).to eq(random_embedding_2.length)
+    page_embedding_2.embedding.take(5).zip(random_embedding_2.take(5)).each do |actual, expected|
+      expect(actual).to be_within(0.01).of(expected)
+    end
+
+    expect(PageEmbedding.count).to eq(1)
+  end
 end


### PR DESCRIPTION
Two key changes:

1. Improve how the custom `Vector` column type to play nice with ActiveRecord. By adding some additional logic to the serialization method, we can avoid needing a `custom_create` method.
2. Implement the similar page query as an association on Page. To do this, we build a subquery to perform the embed matching, inspired by the KNN query examples in the sqlite-vec docs ([link](https://alexgarcia.xyz/sqlite-vec/features/knn.html)). We do some interesting shenanigans in the query, including `unscope(:where)` and `where.associated(:page_embedding)` to ensure we can query _other_ pages and only those associated with a page embedding.