### PR TITLE
Add to ActiveRecord::SchemaDumper.ignore_tables for sqlite-vec

### DIFF
--- a/config/initializers/schema_dumper.rb
+++ b/config/initializers/schema_dumper.rb
@@ -1,0 +1,8 @@
+ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
+
+# Ignore tables managed by the sqlite-vec extension
+# matches tables like: page_embeddings_chunks, page_embeddings_chunks00, and
+# page_embeddings_rowids
+ignore_tables += [/_chunks\d*$/] + [/_rowids$/]
+
+ActiveRecord::SchemaDumper.ignore_tables = ignore_tables

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -165,9 +165,6 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_15_130544) do
     t.index ["recipient_type", "recipient_id"], name: "index_notifications_on_recipient"
   end
 
-  # Could not dump table "page_embeddings_vector_chunks00" because of following StandardError
-  #   Unknown type '' for column 'rowid'
-
   create_table "page_topics", force: :cascade do |t|
     t.string "page_id", null: false
     t.integer "topic_id", null: false


### PR DESCRIPTION
Before this change, auxiliary tables created by sqlite-vec for storing and managing vector embeddings would result in undesired changes to db/schema.rb when running subsequent migrations:

$ bin/rails db:migrate

=>

```diff
+  create_table "page_embeddings_chunks", primary_key: "chunk_id", force: :cascade do |t|
+    t.integer "size", null: false
+    t.binary "validity", null: false
+    t.binary "rowids", null: false
+  end
+
+  create_table "page_embeddings_rowids", primary_key: "rowid", force: :cascade do |t|
+    t.text "id", null: false
+    t.integer "chunk_id"
+    t.integer "chunk_offset"
+  end
+
+# Could not dump table "page_embeddings_vector_chunks00" because of following StandardError
+#   Unknown type '' for column 'rowid'
+
```

With this schema change, Rails will attempt to recreate these tables when the schema is loaded for specs when they should otherwise be managed by sqlite-vec internal logic, resulting in a catastrophic error (cannot create table that already exists).

To address this issue without otherwise editing AR schema logic or sqlite-vec code, we can take advantage of
ActiveRecord::SchemaDumper.ignore_tables which allows us to specify tables like this that should not be includes in the Rails schema dump.

We can identify these tables by regex since Rails 7. https://blog.saeloun.com/2023/01/10/rails-add-ability-to-ignore-tables-by-regexp

Tested by running `bin/rails db:schema:dump` and re-running specs.
