### PR TITLE
Power atom feed from Page records

### DIFF
--- a/app/content/models/sitepress_article.rb
+++ b/app/content/models/sitepress_article.rb
@@ -43,12 +43,4 @@ class SitepressArticle < Sitepress::Model
     updated&.to_date || published_on
   end
   alias_method :updated_at, :updated_on
-
-  def gravatar_image_url
-    "https://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(email)}"
-  end
-
-  def author
-    data.author || "Ross Kaffenberger"
-  end
 end

--- a/app/controllers/feed_controller.rb
+++ b/app/controllers/feed_controller.rb
@@ -1,6 +1,6 @@
 class FeedController < ApplicationController
   def index
-    @articles = SitepressArticle.published
+    @articles = Page.published.order(published_at: :desc).limit(50)
 
     if Rails.configuration.skip_http_cache || stale?(@articles, public: true)
       respond_to do |format|

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -30,9 +30,6 @@ class Page < ApplicationRecord
   scope :published, -> { where(["published_at < ?", Time.zone.now]) }
   scope :indexed, -> { where(["indexed_at < ?", Time.zone.now]) }
 
-  # def resource_data
-  delegate :data, to: :resource, allow_nil: true, prefix: true
-
   def published? = !!published_at
 
   def published_on = published_at&.to_date
@@ -58,5 +55,11 @@ class Page < ApplicationRecord
 
   def toc = resource.data.toc
 
-  def enable_twitter_widgets = resource.data.toc
+  def enable_twitter_widgets = resource.data.enable_twitter_widgets
+
+  def atom_feed_id
+    resource.data.uuid.presence || id
+  end
+
+  def author = resource.data.author
 end

--- a/app/views/feed/index.atom.builder
+++ b/app/views/feed/index.atom.builder
@@ -1,11 +1,11 @@
 atom_feed do |feed|
   feed.title(Rails.configuration.x.application_name)
-  feed.updated(@articles.first.published_on) if @articles.length > 0
+  feed.updated(@articles.first.published_at) if @articles.length > 0
 
   @articles.take(50).each do |article|
     feed.entry(
       article,
-      id: "tag:#{request.host},2005:article/#{article.data.uuid!}",
+      id: "tag:#{request.host},2005:article/#{article.atom_feed_id}",
       url: request.base_url + article.request_path
     ) do |entry|
       entry.title(article.title)

--- a/lib/generators/article/article_generator.rb
+++ b/lib/generators/article/article_generator.rb
@@ -14,7 +14,7 @@ class ArticleGenerator < Rails::Generators::NamedBase
   end
 
   def add_spec
-    template "article_spec.rb", "spec/system/articles/#{article_file_name}_spec.rb"
+    template "article_spec.rb", "spec/system/content/#{article_file_name}_spec.rb"
   end
 
   private

--- a/lib/generators/article/templates/article.html.mdrb.tt
+++ b/lib/generators/article/templates/article.html.mdrb.tt
@@ -5,7 +5,6 @@ layout: article
 summary: Here is the summary
 description: Here is the description that will show up in the the meta day
 published: "<%= Date.today + 7 %>"
-uuid: <%= SecureRandom.uuid_v7 %>
 image: articles/<%= article_file_name %>/placeholder.jpg
 meta_image: articles/<%= article_file_name %>/placeholder.jpg
 tags:

--- a/spec/generators/articles_generator_spec.rb
+++ b/spec/generators/articles_generator_spec.rb
@@ -10,9 +10,6 @@ RSpec.describe ArticleGenerator, type: :generator do
   end
 
   it "creates a new article" do
-    uuid = "00000000-0000-0000-0000-000000000000"
-    allow(SecureRandom).to receive(:uuid_v7).and_return(uuid)
-
     run_generator ["My New Article"]
 
     aggregate_failures do
@@ -27,7 +24,6 @@ RSpec.describe ArticleGenerator, type: :generator do
           summary: Here is the summary
           description: Here is the description that will show up in the the meta day
           published: "#{Date.today + 7}"
-          uuid: #{uuid}
           image: articles/my-new-article/placeholder.jpg
           meta_image: articles/my-new-article/placeholder.jpg
           tags:
@@ -38,7 +34,7 @@ RSpec.describe ArticleGenerator, type: :generator do
         FILE
       end
 
-      expect("spec/system/articles/my-new-article_spec.rb").to be_file
+      expect("spec/system/content/my-new-article_spec.rb").to be_file
     end
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -18,9 +18,31 @@
 require "rails_helper"
 
 RSpec.describe Page, type: :model do
-  it "represents a sitepress resource" do
-    page = FactoryBot.create(:page, request_path: "/")
+  describe "#resource" do
+    it "represents a sitepress resource" do
+      page = FactoryBot.create(:page, request_path: "/")
 
-    expect(page.resource).to eq Sitepress.site.get("/")
+      expect(page.resource).to eq Sitepress.site.get("/")
+    end
+  end
+
+  describe "#body" do
+    it "delegates to resource" do
+      page = FactoryBot.build(:page, request_path: "/articles/introducing-joy-of-rails")
+
+      expect(page.body).to be_present
+      expect(page.body).to eq page.resource.body
+    end
+  end
+
+  describe "resource data methods" do
+    it "delegates to resource data" do
+      page = FactoryBot.build(:page, request_path: "/articles/introducing-joy-of-rails")
+
+      %w[title description image meta_image toc author].each do |method|
+        expect(page.send(method)).not_to be_nil, "Expected #{method} to be present"
+        expect(page.send(method)).to eq(page.resource.data.send(method)), "Expected #{method} to match"
+      end
+    end
   end
 end

--- a/spec/requests/feed_spec.rb
+++ b/spec/requests/feed_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe "Feed", type: :request do
 
   describe "GET /feed" do
     it "renders feed with expected content" do
+      Page.upsert_collection_from_sitepress!
+
       get "/feed"
 
       expect(response.status).to eq(200)
@@ -24,6 +26,8 @@ RSpec.describe "Feed", type: :request do
     end
 
     it "render valid feed" do
+      Page.upsert_collection_from_sitepress!
+
       get "/feed"
 
       validator = W3CValidators::FeedValidator.new


### PR DESCRIPTION
Now that we `Page` records that can be queried by published data and can delegate to a corresponding Sitepress resource, we can update the atom feed to query `Page.published`. 

We no longer need a `uuid` in markdown metadata. We add a `Page#atom_feed_id` to ensure "old" atom feed entries retain their pre-exising uuids—otherwise, atom feed services will think new articles are published in place of the old.