### PR TITLE
Refactor Page#related_pages with ActiveRecord::Relation#with

### DIFF
--- a/app/models/page/similarity.rb
+++ b/app/models/page/similarity.rb
@@ -36,10 +36,10 @@ class Page
 
         select("pages.*")
           .select("similar_pages.distance")
-          .from("(#{similar_page_subquery.to_sql}) similar_pages")
-          .joins("INNER JOIN pages ON similar_pages.id = pages.id")
-          .where("similar_pages.id != ?", page.id)
-          .order("similar_pages.distance ASC")
+          .with(similar_pages: similar_page_subquery)
+          .joins("INNER JOIN similar_pages ON pages.id = similar_pages.id")
+          .excluding(page)
+          .order(distance: :asc)
       end
     end
   end

--- a/app/models/page/similarity.rb
+++ b/app/models/page/similarity.rb
@@ -28,16 +28,15 @@ class Page
       scope :similar_to, ->(page) do
         return none unless page.page_embedding
 
-        similar_page_subquery = PageEmbedding
-          .where("embedding MATCH (?)", PageEmbedding.select(:embedding).where(id: page.id))
-          .select(:id, :distance)
-          .order(distance: :asc)
-          .limit(10)
-
-        select("pages.*")
-          .select("similar_pages.distance")
-          .with(similar_pages: similar_page_subquery)
-          .joins("INNER JOIN similar_pages ON pages.id = similar_pages.id")
+        select(pages: [:id, :request_path, :published_at], similar_embeddings: [:distance])
+          .with(
+            similar_embeddings: PageEmbedding
+              .select(:id, :distance)
+              .where("embedding MATCH (?)", PageEmbedding.select(:embedding).where(id: page.id))
+              .order(distance: :asc)
+              .limit(10)
+          )
+          .joins("INNER JOIN similar_embeddings ON pages.id = similar_embeddings.id")
           .excluding(page)
           .order(distance: :asc)
       end

--- a/app/models/page_embedding.rb
+++ b/app/models/page_embedding.rb
@@ -7,6 +7,11 @@ class PageEmbedding < ApplicationRecord
 
   belongs_to :page, inverse_of: :page_embedding, foreign_key: :id, primary_key: :id, touch: true
 
+  scope :similar_to, ->(page) do
+    select(:id, :distance)
+      .where("embedding MATCH (?)", PageEmbedding.select(:embedding).where(id: page.id))
+  end
+
   # SQLite supports upserts via INSERT ON CONFLICT DO UPDATE for normal tables
   # but not for virtual tables. This method behaves like an upsert the embedding
   # for a page by first removing the existing embedding if it exists and then


### PR DESCRIPTION
I recently discovered Rails has Common Table Expression support https://blog.kiprosh.com/rails-7-1-construct-cte-using-with-query-method/

This is allows to rewrite the "similar_to" Page scope that backs the "related_pages" association using a CTE for the PageEmbedding subquery.

<!-- Describe your changes and link to relevant issues or discussions. Please add motivation and context as needed. -->

## Pull request checklist

- [x] I have written tests for code I have added or modified.
- [x] I linted and tested the project with `bin/verify`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
