### PR TITLE
Update litestream configuration

### DIFF
--- a/app/lib/litestream_extensions/setup.rb
+++ b/app/lib/litestream_extensions/setup.rb
@@ -11,7 +11,7 @@ module LitestreamExtensions
     end
 
     def config_path
-      Rails.root.join("config", "litestream", "#{Rails.env}.yml")
+      Rails.env.production? ? Rails.root.join("config", "litestream.yml") : Rails.root.join("config", "litestream", "#{Rails.env}.yml")
     end
 
     def litestream_config

--- a/app/lib/litestream_extensions/setup.rb
+++ b/app/lib/litestream_extensions/setup.rb
@@ -8,6 +8,9 @@ module LitestreamExtensions
         return
       end
       File.write(config_path, YAML.dump(litestream_config))
+
+      # Here’s the command needed to check the status of the Litestream service on Hatchbox:
+      Litestream.systemctl_command = "systemctl --user status joyofrails-litestream.service"
     end
 
     def config_path

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,0 +1,4 @@
+production:
+  litestream_verify:
+    class: "Litestream::VerificationJob"
+    schedule: every day at 6am


### PR DESCRIPTION
Litestream Ruby provides some useful features we’re not fully able to take advantage of because a) we’re using a custom config path, b) some features assume the default config path. Until Litestream is more configurable, we’ll set the path back to the default in production.

One of these features is the Litestream verification job. This is now configured to run on a daily basis to make sure Litestream is running properly. A TODO with this change is to start a new process in production to run Solid Queue recurring jobs.

We’ll also configure the custom systemd command with the new option provided by my PR here https://github.com/fractaledmind/litestream-ruby/pull/39

TODO

- [ ] Start process for Solid Queue recurring tasks in production https://github.com/rails/solid_queue?tab=readme-ov-file#recurring-tasks