### PR TITLE
Homepage spacing and article header updates

### DIFF
--- a/app/content/layouts/article.html.erb
+++ b/app/content/layouts/article.html.erb
@@ -15,19 +15,22 @@
 <%= render "application/skip_to_content" %>
 <%= render_layout "application" do %>
   <article itemscope itemtype="http://schema.org/Article" class="mb-3xl">
-    <%= render Pages::Header.new(
-          title: page.title,
-          description: page.description,
-          published_on: page.published_on,
-          updated_on: page.revised_on
-        ) %>
+    <%= render Pages::Header::Container.new do |c| %>
+      <%= c.title { page.title } %>
+      <%= c.description { page.description } if page.description %>
+      <div class="flex flex-col lg:flex-row justify-between">
+        <%= render Pages::Timestamp.new published_on: page.published_on, updated_on: page.revised_on, class: "text-small" %>
+        <span class="text-small">
+          <% topics = @page.topics.approved.pluck(:slug) %>
+          <% if topics.present? %>
+            <%= render Pages::Topics.new(topics: topics) %>
+          <% end %>
+        </span>
+      </div>
+    <% end %>
     <div class="article-content container" itemprop="articleBody">
       <%= yield %>
 
-      <% topics = @page.topics.approved.pluck(:slug) %>
-      <% if topics.present? %>
-        <%= render Pages::Topics.new(topics: topics) %>
-      <% end %>
       <% cache [@page, :related_pages] do %>
         <% related_pages = @page.related_pages.published.limit(3) %>
         <% if related_pages.present? %>

--- a/app/content/pages/articles/add-your-rails-app-to-the-home-screen.html.mdrb
+++ b/app/content/pages/articles/add-your-rails-app-to-the-home-screen.html.mdrb
@@ -454,6 +454,4 @@ Did you find a bug or do you have questions about the content? You can [send me 
 
 Curious to peek behind the curtain and get a glimpse of the magic? [Joy of Rails is open source on Github](https://github.com/joyofrails/joyofrails.com). Feel free to look through the code and contribute.
 
-That does it for another glimpse into what’s possible with Ruby on Rails. I hope you enjoyed it.
-
-![Hot Air Balloon](articles/add-your-rails-app-to-the-home-screen/hot-air-balloon.jpg 'Hot Air Balloon, by Jasper (my son)')
+That does it for another glimpse into what’s possible with Ruby on Rails. I hope you enjoyed it. ![Hot Air Balloon](articles/add-your-rails-app-to-the-home-screen/hot-air-balloon.jpg 'Hot Air Balloon, by Jasper (my son)')

--- a/app/content/pages/articles/custom-color-schemes-with-ruby-on-rails.html.mdrb
+++ b/app/content/pages/articles/custom-color-schemes-with-ruby-on-rails.html.mdrb
@@ -152,6 +152,4 @@ Curious to peek behind the curtain and get a glimpse of the magic? [Joy of Rails
 
 And if I’ve captured your interest, please [subscribe](#newsletter-signup) to hear more from me and get notified of new articles by email.
 
-That does it for another glimpse into what’s possible with Ruby on Rails. I hope you enjoyed it.
-
-![Rainbow](articles/custom-color-schemes-with-ruby-on-rails/rainbows.jpg 'Rainbow, by Jasper (my son)')
+That does it for another glimpse into what’s possible with Ruby on Rails. I hope you enjoyed it. ![Rainbow](articles/custom-color-schemes-with-ruby-on-rails/rainbows.jpg 'Rainbow, by Jasper (my son)')

--- a/app/content/pages/articles/mastering-custom-configuration-in-rails.html.mdrb
+++ b/app/content/pages/articles/mastering-custom-configuration-in-rails.html.mdrb
@@ -419,6 +419,4 @@ Did you find a bug or do you have questions about the content? You can [send me 
 
 [Joy of Rails is open source on Github](https://github.com/joyofrails/joyofrails.com). Feel free to look through the code and contribute.
 
-That does it for another glimpse into what’s possible with Ruby on Rails. I hope you enjoyed it.
-
-![Ice cream](articles/mastering-custom-configuration-in-rails/ice-cream.jpg 'Ice cream')
+That does it for another glimpse into what’s possible with Ruby on Rails. I hope you enjoyed it. ![Ice cream](articles/mastering-custom-configuration-in-rails/ice-cream.jpg 'Ice cream')

--- a/app/content/pages/articles/web-push-notifications-from-rails.html.mdrb
+++ b/app/content/pages/articles/web-push-notifications-from-rails.html.mdrb
@@ -539,6 +539,4 @@ Did you find a bug or do you have questions about the content? You can [send me 
 
 Curious to peek behind the curtain and get a glimpse of the magic? [Joy of Rails is open source on Github](https://github.com/joyofrails/joyofrails.com). Feel free to look through the code and contribute.
 
-That does it for another glimpse into what’s possible with Ruby on Rails. I hope you enjoyed it.
-
-![Airplane](articles/web-push-notifications-from-rails/airplane.jpg 'Airplane')
+That does it for another glimpse into what’s possible with Ruby on Rails. I hope you enjoyed it. ![Airplane](articles/web-push-notifications-from-rails/airplane.jpg 'Airplane')

--- a/app/content/pages/articles/what-you-need-to-know-about-sqlite.html.mdrb
+++ b/app/content/pages/articles/what-you-need-to-know-about-sqlite.html.mdrb
@@ -369,6 +369,4 @@ If you liked this article, please feel free to share it and [subscribe](#newslet
 
 Did you find a mistake or do you have questions about the content? You can [send me an email](mailto:ross@joyofrails.com), connect with me on [Twitter](https://x.com/rossta), [Bluesky](https://bsky.app/profile/rossta.net), [Github](https://github.com/rossta), [Mastodon](https://ruby.social/@rossta), and/or [Linkedin](https://www.linkedin.com/in/rosskaffenberger).
 
-Curious to peek behind the curtain and get a glimpse of the magic? [Joy of Rails is open source on Github](https://github.com/joyofrails/joyofrails.com). Feel free to look through the code and contribute.
-
-![Feather](articles/what-you-need-to-know-about-sqlite/feather.jpg 'Feather')
+Curious to peek behind the curtain and get a glimpse of the magic? [Joy of Rails is open source on Github](https://github.com/joyofrails/joyofrails.com). Feel free to look through the code and contribute. ![Feather](articles/what-you-need-to-know-about-sqlite/feather.jpg 'Feather')

--- a/app/javascript/css/application.css
+++ b/app/javascript/css/application.css
@@ -47,3 +47,4 @@
 @import './components/snippet.css';
 @import './components/snippet.css';
 @import './components/table.css';
+@import './components/time.css';

--- a/app/javascript/css/components/article-content.css
+++ b/app/javascript/css/components/article-content.css
@@ -7,7 +7,7 @@
   & h5,
   & h6 {
     color: var(--joy-text-heading);
-    margin-block-start: var(--space-m);
+    margin-block-start: var(--space-xl);
   }
 
   & hr {

--- a/app/javascript/css/components/page-header.css
+++ b/app/javascript/css/components/page-header.css
@@ -2,15 +2,6 @@
   background-color: var(--joy-background-header);
   padding-block-start: var(--grid-gutter);
   padding-block-end: var(--grid-gutter);
-
-  & .description {
-    font-size: var(--step-1);
-  }
-
-  & time {
-    font-size: var(--step--1);
-    color: var(--joy-text-subtle);
-  }
 }
 
 .extend-page-header-bg {

--- a/app/javascript/css/components/time.css
+++ b/app/javascript/css/components/time.css
@@ -1,0 +1,4 @@
+time {
+  font-size: var(--step--1);
+  color: var(--joy-text-subtle);
+}

--- a/app/javascript/css/utilities/tailwind-media.scss
+++ b/app/javascript/css/utilities/tailwind-media.scss
@@ -126,6 +126,14 @@
     display: flex;
   }
 
+  .lg\:flex-row {
+    flex-direction: row;
+  }
+
+  .lg\:flex-row-reverse {
+    flex-direction: row-reverse;
+  }
+
   .lg\:hidden {
     display: none;
   }

--- a/app/javascript/css/utilities/tailwind.css
+++ b/app/javascript/css/utilities/tailwind.css
@@ -412,6 +412,10 @@
   justify-content: space-between;
 }
 
+.content-start {
+  align-content: flex-start;
+}
+
 .gap-0 {
   gap: 0px;
 }

--- a/app/views/author/snippets/snippet.rb
+++ b/app/views/author/snippets/snippet.rb
@@ -26,7 +26,7 @@ module Author
           div(class: "keep-style-when-linked") do
             render Pages::Timestamp.new \
               published_on: snippet.created_at.to_date,
-              class: "text-small"
+              class: "block text-small"
           end
 
           div do

--- a/app/views/components/pages/header.rb
+++ b/app/views/components/pages/header.rb
@@ -25,7 +25,7 @@ module Pages
       end
 
       def title(&)
-        h1(&)
+        h1(class: "mb-4", &)
       end
 
       def description(&)

--- a/app/views/components/pages/header.rb
+++ b/app/views/components/pages/header.rb
@@ -13,7 +13,9 @@ module Pages
       render Container.new do |c|
         c.title { title }
         c.description { description } if description
-        render Pages::Timestamp.new published_on: published_on, updated_on: updated_on
+        div do
+          render Pages::Timestamp.new published_on: published_on, updated_on: updated_on
+        end
       end
     end
 

--- a/app/views/components/pages/summary.rb
+++ b/app/views/components/pages/summary.rb
@@ -45,7 +45,7 @@ module Pages
         end
         p(class: "description") { description } if description
         if published_on
-          render Pages::Timestamp.new published_on: published_on
+          render Pages::Timestamp.new published_on: published_on, class: "block"
         end
         a(href: request_path, class: "block uppercase strong") do
           small { "Read now" }

--- a/app/views/components/pages/summary.rb
+++ b/app/views/components/pages/summary.rb
@@ -29,10 +29,10 @@ module Pages
       div(class: "page-summary grid grid-gap lg:grid-cols-2 lg:grid-flow-col") do
         case side
         when "left"
-          content(class: "grid lg:text-right lg:grid-column-start-1")
+          content(class: "grid grid-row-tight content-start lg:text-right lg:grid-column-start-1")
           figure_image(class: "grid grid-row-tight lg:text-left lg:grid-column-start-2")
         else
-          content(class: "grid lg:text-left lg:grid-column-start-2")
+          content(class: "grid grid-row-tight content-start lg:text-left lg:grid-column-start-2")
           figure_image(class: "grid grid-row-tight lg:text-right lg:grid-column-start-1")
         end
       end
@@ -40,7 +40,7 @@ module Pages
 
     def content(**)
       div(**) do
-        a(href: request_path) do
+        a(href: request_path, class: "mb-4") do
           h2(class: "important") { title }
         end
         p(class: "description") { description } if description

--- a/app/views/components/pages/summary.rb
+++ b/app/views/components/pages/summary.rb
@@ -14,6 +14,8 @@ module Pages
       )
     end
 
+    attr_reader :title, :description, :published_on, :image, :request_path, :side
+
     def initialize(title: nil, description: nil, published_on: nil, image: nil, request_path: nil, side: "right")
       @title = title
       @description = description
@@ -25,39 +27,36 @@ module Pages
 
     def view_template
       div(class: "page-summary grid grid-gap lg:grid-cols-2 lg:grid-flow-col") do
-        case @side
+        case side
         when "left"
-          content(class: "grid grid-row-tight lg:text-right lg:grid-column-start-1")
-          image(class: "grid grid-row-tight lg:text-left lg:grid-column-start-2")
+          content(class: "grid lg:text-right lg:grid-column-start-1")
+          figure_image(class: "grid grid-row-tight lg:text-left lg:grid-column-start-2")
         else
-          content(class: "grid grid-row-tight lg:text-left lg:grid-column-start-2")
-          image(class: "grid grid-row-tight lg:text-right lg:grid-column-start-1")
+          content(class: "grid lg:text-left lg:grid-column-start-2")
+          figure_image(class: "grid grid-row-tight lg:text-right lg:grid-column-start-1")
         end
       end
     end
 
     def content(**)
       div(**) do
-        a(href: @request_path) do
-          h2(class: "important") { @title }
+        a(href: request_path) do
+          h2(class: "important") { title }
         end
-        p(class: "description") { @description } if @description
-        if @published_on
-          span(class: "block") do
-            # <time datetime="2024-03-13T00:00:00Z" itemprop="datePublished" class="dt-published"> March 13th, 2024 </time>
-            time_tag @published_on, itemprop: "datePublished", class: "dt-published"
-          end
+        p(class: "description") { description } if description
+        if published_on
+          render Pages::Timestamp.new published_on: published_on
         end
-        a(href: @request_path, class: "block uppercase strong") do
+        a(href: request_path, class: "block uppercase strong") do
           small { "Read now" }
         end
       end
     end
 
-    def image(**)
+    def figure_image(**)
       div(**) do
         figure(class: "page-summary--image") do
-          image_tag @image, class: "w-full object-cover aspect-[2/1] lg:aspect-[3/2]"
+          image_tag image, class: "w-full object-cover aspect-[2/1] lg:aspect-[3/2]"
         end
       rescue
         ActionView::Template::Error

--- a/app/views/components/pages/timestamp.rb
+++ b/app/views/components/pages/timestamp.rb
@@ -12,7 +12,7 @@ module Pages
 
     def view_template
       if published_on || updated_on
-        span(**mix(attributes, class: "block")) do
+        span(**mix(attributes)) do
           if published_on && updated_on
             plain "Published:"
             whitespace

--- a/app/views/components/pages/topics.rb
+++ b/app/views/components/pages/topics.rb
@@ -12,13 +12,11 @@ module Pages
         return
       end
 
-      p(class: "topics") do
-        topics.each do |topic|
-          a(href: topic_path(topic), class: "topic") do
-            "##{topic.try(:slug) || topic}"
-          end
-          whitespace
+      topics.each do |topic|
+        a(href: topic_path(topic), class: "topic") do
+          topic.try(:slug) || topic
         end
+        whitespace
       end
     end
   end

--- a/app/views/share/snippets/snippet.rb
+++ b/app/views/share/snippets/snippet.rb
@@ -26,7 +26,7 @@ module Share
           div(class: "keep-style-when-linked") do
             render Pages::Timestamp.new \
               published_on: snippet.created_at.to_date,
-              class: "text-small"
+              class: "block text-small"
           end
 
           div do

--- a/spec/system/articles_spec.rb
+++ b/spec/system/articles_spec.rb
@@ -37,14 +37,14 @@ RSpec.describe "Articles", type: :system do
     expect(article.topics.approved.count).to eq(2)
 
     article.topics.approved.each do |topic|
-      expect(page).to have_link("##{topic.slug}", href: topic_path(topic))
+      expect(page).to have_link(topic.slug, href: topic_path(topic))
     end
     (article.topics.rejected + article.topics.pending).each do |topic|
-      expect(page).not_to have_link("##{topic.slug}", href: topic_path(topic))
+      expect(page).not_to have_link(topic.slug, href: topic_path(topic))
     end
 
     first_topic = article.topics.first
-    click_link "##{first_topic.slug}"
+    click_link first_topic.slug
 
     within("header.page-header") do
       expect(page).to have_content("Topics")


### PR DESCRIPTION
## Homepage summary text spacing

TIL about `align-content` for grid/flex spacing for spacing along the _cross_ axis—as opposed to the complementary property I was more familiar with, `justify-content`, for grid/flex spacing along the main axis.

https://developer.mozilla.org/en-US/docs/Web/CSS/align-content
https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content

This helped me fix some spacing issues in the homepage article summaries from this:
![Screenshot 2024-12-07 at 9 51 18 AM](https://github.com/user-attachments/assets/fed57e64-c8af-4275-922e-e5f894b739f6)

To this:
![Screenshot 2024-12-07 at 9 51 05 AM](https://github.com/user-attachments/assets/cbf8a93e-abaa-453d-8d4a-47c9640141ff)

The latter has tighter spacing since it doesn’t stretch to fill the box. This also means the spacing in each summary is consistent with respect to the space between text.

## Article topics in header

Previously, topic links were buried as the bottom of the articles. Now I've moved them to the header
![Screenshot 2024-12-07 at 9 51 44 AM](https://github.com/user-attachments/assets/0370ed2a-337b-43ab-920f-f2ac669b69ea)

