### PR TITLE
Embed polls in articles

### DIFF
--- a/app/content/pages/articles/what-you-need-to-know-about-sqlite.html.mdrb
+++ b/app/content/pages/articles/what-you-need-to-know-about-sqlite.html.mdrb
@@ -17,6 +17,8 @@ It’s basically this: computers have gotten faster, and Rails has finally figur
 
 With the recent release of Rails 8, it’s easier than ever to choose SQLite as your primary database for production. The question is, _should you?_
 
+<%= render Share::Polls::LazyPagePoll.new(Current.page, "SQLite on Rails Poll", "How likely are you to use SQLite in your Rails app?" => ["100%", "Strongly considering", "On the fence", "Not very, but open minded", "No way"]) %>
+
 ## SQLite3::Database.open
 
 [Joy of Rails](/) has run on SQLite since launch, and I have been very happy with my choice—I plan to keep it that way. But SQLite isn’t for everyone.

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -6,7 +6,7 @@ class SiteController < Sitepress::SiteController
   # requested_resource is the Sitepress::Resource object that represents the current page.
   #
   def show
-    @page = Page.find_or_initialize_by(request_path: request.path)
+    Current.page = @page = Page.find_or_initialize_by(request_path: request.path)
 
     super
   end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -2,4 +2,5 @@ class Current < ActiveSupport::CurrentAttributes
   attribute :admin_user
   attribute :user
   attribute :color_scheme
+  attribute :page
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -34,9 +34,9 @@ class Page < ApplicationRecord
   scope :draft, -> { where(["published_at > ?", Time.zone.now]) }
   scope :indexed, -> { where(["indexed_at < ?", Time.zone.now]) }
 
-  def self.primary_author
-    User.find_by!(email: Rails.configuration.x.emails.primary_author)
-  end
+  def self.primary_author = User.find_by(email: Rails.configuration.x.emails.primary_author)
+
+  def self.primary_author! = User.find_by!(email: Rails.configuration.x.emails.primary_author)
 
   def published? = !!published_at
 

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -35,8 +35,8 @@ class Poll < ApplicationRecord
     questions = {}
   )
     poll = page.polls.find_by(title: title) and return poll
-
-    poll = Page.primary_author.polls.create!(title: title)
+    author = Page.primary_author or return nil
+    poll = author.polls.create!(title: title)
     poll.pages << page
     poll.questions = questions.map do |question_body, answers|
       question = poll.questions.build(body: question_body)

--- a/app/views/feed/index.atom.builder
+++ b/app/views/feed/index.atom.builder
@@ -4,6 +4,7 @@ atom_feed do |feed|
 
   @articles.take(50).each do |article|
     next if article.resource_missing?
+    Current.page = article
 
     feed.entry(
       article,

--- a/app/views/share/polls/_poll.html.erb
+++ b/app/views/share/polls/_poll.html.erb
@@ -1,13 +1,1 @@
-<%= turbo_frame_tag poll, class: "poll joy-border-subtle rounded" do %>
-  <header class="px-4 pt-2 pb-2">
-    <h5>
-      <%= poll.title %>
-    </h5>
-  </header>
-
-  <div class="p-4 flex flex-col gap-2">
-    <% poll.questions.includes(:answers).ordered.each do |question| %>
-      <%= render Share::Polls::Question.new(poll:, question:, voted: question.voted?(device_uuid: ensure_device_uuid)) %>
-    <% end %>
-  </div>
-<% end %>
+<%= render Share::Polls::PollComponent.new(poll, device_uuid: ensure_device_uuid) %>

--- a/app/views/share/polls/lazy_page_poll.rb
+++ b/app/views/share/polls/lazy_page_poll.rb
@@ -1,0 +1,29 @@
+module Share
+  module Polls
+    class LazyPagePoll < ApplicationComponent
+      include Phlex::Rails::Helpers::Provide
+      include Phlex::Rails::Helpers::Request
+      include Phlex::Rails::Helpers::TurboRefreshesWith
+
+      attr_reader :page, :title, :question_data
+      def initialize(page, title, question_data = {})
+        @page = page
+        @title = title
+        @question_data = question_data
+      end
+
+      def view_template
+        poll = Poll.generate_for(page, title, question_data) or return
+
+        provide :head, turbo_refreshes_with(method: :morph, scroll: :preserve)
+        render Share::Polls::PollComponent.new(poll, device_uuid: device_uuid)
+      end
+
+      def device_uuid
+        return "" unless helpers.request.key_generator
+
+        helpers.cookies.signed[:device_uuid]
+      end
+    end
+  end
+end

--- a/app/views/share/polls/poll_component.rb
+++ b/app/views/share/polls/poll_component.rb
@@ -1,0 +1,34 @@
+class Share::Polls::PollComponent < ApplicationComponent
+  include Phlex::Rails::Helpers::TurboFrameTag
+
+  attr_accessor :poll, :device_uuid
+
+  def initialize(poll, device_uuid:)
+    @poll = poll
+    @device_uuid = device_uuid
+  end
+
+  def view_template
+    turbo_frame_tag poll, class: "poll joy-border-subtle rounded" do
+      header(class: "px-4 pt-2 pb-2") do
+        h5 do
+          plain poll.title
+        end
+      end
+
+      div(class: "p-4 flex flex-col gap-2") do
+        poll
+          .questions
+          .includes(:answers)
+          .ordered
+          .each do |question|
+            render Share::Polls::Question.new(
+              poll:,
+              question:,
+              voted: question.voted?(device_uuid: device_uuid)
+            )
+          end
+      end
+    end
+  end
+end

--- a/spec/system/content/what-you-need-to-know-about-sqlite_spec.rb
+++ b/spec/system/content/what-you-need-to-know-about-sqlite_spec.rb
@@ -1,9 +1,19 @@
 require "rails_helper"
 
 RSpec.describe "What you need to know about SQLite", type: :system do
-  it "displays the article content" do
+  it "displays the article content if primary poll author does not exist" do
     visit "/articles/what-you-need-to-know-about-sqlite"
 
     expect(page).to have_content "What you need to know about SQLite"
+  end
+
+  it "displays the article content with poll by primary author" do
+    FactoryBot.create(:user, :primary_author)
+
+    visit "/articles/what-you-need-to-know-about-sqlite"
+
+    expect(page).to have_content "What you need to know about SQLite"
+
+    expect(page).to have_content "How likely are you to use SQLite in your Rails app?"
   end
 end


### PR DESCRIPTION
Some hacks to lazy create a poll within the content of an article. Uses some globally-accessible values like `Page.primary_author` and `Current.page` to access knowledge of key records with content rendering in a request and within atom feeds. Hacks and workarounds galore!