### PR TITLE
Make it possible to run CI without project secrets

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -55,8 +55,6 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
-    env:
-      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_TEST_KEY }}
 
     steps:
       - name: Checkout code
@@ -159,8 +157,6 @@ jobs:
   npm-test:
     name: Tests - JavaScript
     runs-on: ubuntu-latest
-    env:
-      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_TEST_KEY }}
 
     steps:
       - name: Checkout code
@@ -196,7 +192,6 @@ jobs:
   assets:
     name: Assets
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -226,8 +221,6 @@ jobs:
 
       - name: Make sure assets compile
         run: |
-          RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_PRODUCTION_KEY }} \
-          RAILS_ENV=production \
           bin/rails assets:precompile
 
       - uses: actions/upload-artifact@v4
@@ -240,7 +233,7 @@ jobs:
     name: Boot
     runs-on: ubuntu-latest
     env:
-      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_PRODUCTION_KEY }}
+      RAILS_MASTER_PRODUCTION_KEY: ${{ secrets.RAILS_MASTER_PRODUCTION_KEY }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -268,11 +261,24 @@ jobs:
         run: |
           bin/sqlpkg install
 
-      - name: Start Rails server in the background
+      - name: Start Rails server in the background (test)
         run: |
-          RAILS_FORCE_SSL=false bundle exec puma -b tcp://127.0.0.1:3001 -e production &
-          sleep 10
+          bundle exec puma -b tcp://127.0.0.1:3001 -e test &
 
-      - name: Make sure the server is running
+      - name: Start Rails server in the background (production)
+        if: ${{ env.RAILS_MASTER_PRODUCTION_KEY != '' }}
+        run: |
+          RAILS_MASTER_KEY=$RAILS_MASTER_PRODUCTION_KEY \
+          RAILS_FORCE_SSL=false bundle exec puma -b tcp://127.0.0.1:3002 -e production &
+
+      - name: Wait for the servers to start
+        run: sleep 10
+
+      - name: Make sure the server is running (test)
         run: |
           bin/up http://127.0.0.1:3001/up
+
+      - name: Make sure the server is running (production)
+        if: ${{ env.RAILS_MASTER_PRODUCTION_KEY != '' }}
+        run: |
+          bin/up http://127.0.0.1:3002/up

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 
-/config/credentials/test.key
 /config/credentials/production.key
 /config/credentials/development.key
 /config/credentials/development.yml.enc

--- a/config/credentials/test.key
+++ b/config/credentials/test.key
@@ -1,0 +1,1 @@
+bb161741ddb450ac2ea8af439cb27fb3


### PR DESCRIPTION
I think we can remove the need for github secrets from CI so collaborator workflows can trigger successfully.

This change makes the `test.key` available to the public repository. The encrypted test credentials file does not and should not contain any actual secrets. 

It’s probably ok not to test asset building in production mode. 

CI will only run the boot test in production mode if the production secret key is available.