### PR TITLE
Run bin/setup in CI for development

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -145,13 +145,9 @@ jobs:
           bin/sqlpkg install
 
       - name: Run local setup script
-        env:
-          RAILS_ENV: test
         run: bin/setup
 
       - name: Run local setup script idempotently
-        env:
-          RAILS_ENV: test
         run: bin/setup
 
   npm-test:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (6.2.2)
+    brakeman (7.0.0)
       racc
     builder (3.3.0)
     bundle-audit (0.1.0)

--- a/db/seeds/development/newsletters.rb
+++ b/db/seeds/development/newsletters.rb
@@ -1,6 +1,6 @@
 start_count_newsletters = 5
 newsletter_fill_count = start_count_newsletters - Newsletter.count
-require 'factory_bot'
-require 'faker'
-require_relative '../../../spec/factories/newsletters'
+require "factory_bot"
+require "faker"
+require_relative "../../../spec/factories/newsletters"
 FactoryBot.create_list(:newsletter, newsletter_fill_count) if newsletter_fill_count > 0

--- a/db/seeds/development/newsletters.rb
+++ b/db/seeds/development/newsletters.rb
@@ -1,6 +1,6 @@
+require "factory_bot_rails"
+
 start_count_newsletters = 5
 newsletter_fill_count = start_count_newsletters - Newsletter.count
-require "factory_bot"
-require "faker"
-require_relative "../../../spec/factories/newsletters"
+
 FactoryBot.create_list(:newsletter, newsletter_fill_count) if newsletter_fill_count > 0

--- a/db/seeds/development/snippets.rb
+++ b/db/seeds/development/snippets.rb
@@ -1,7 +1,7 @@
+require "factory_bot_rails"
+
 snippet_count = 20
 snippet_fill_count = snippet_count - Snippet.count
 user = User.first
-require "factory_bot"
-require "faker"
-require_relative "../../../spec/factories/snippets"
+
 FactoryBot.create_list(:snippet, snippet_fill_count, author: user) if snippet_fill_count > 0

--- a/db/seeds/development/snippets.rb
+++ b/db/seeds/development/snippets.rb
@@ -1,7 +1,7 @@
 snippet_count = 20
 snippet_fill_count = snippet_count - Snippet.count
 user = User.first
-require 'factory_bot'
-require 'faker'
-require_relative '../../../spec/factories/snippets'
+require "factory_bot"
+require "faker"
+require_relative "../../../spec/factories/snippets"
 FactoryBot.create_list(:snippet, snippet_fill_count, author: user) if snippet_fill_count > 0

--- a/spec/factories/newsletters.rb
+++ b/spec/factories/newsletters.rb
@@ -13,6 +13,9 @@
 #
 #  index_newsletters_on_sent_at  (sent_at)
 #
+
+require "faker"
+
 FactoryBot.define do
   factory :newsletter do
     title { Faker::Lorem.sentence }

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -15,6 +15,9 @@
 #  index_pages_on_published_at  (published_at)
 #  index_pages_on_request_path  (request_path) UNIQUE
 #
+
+require "faker"
+
 FactoryBot.define do
   factory :page do
     request_path { "/" + Faker::Internet.slug }

--- a/spec/factories/snippets.rb
+++ b/spec/factories/snippets.rb
@@ -17,6 +17,9 @@
 #
 #  index_snippets_on_author  (author_type,author_id)
 #
+
+require "faker"
+
 FactoryBot.define do
   factory :snippet do
     source { "puts \"Hello, world!\"" }

--- a/spec/models/gravatar_spec.rb
+++ b/spec/models/gravatar_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "faker"
 
 RSpec.describe Gravatar do
   let(:email) { Faker::Internet.email }

--- a/spec/requests/pwa/installation_instructions_spec.rb
+++ b/spec/requests/pwa/installation_instructions_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "faker"
 
 RSpec.describe "/pwa/installation_instructions", type: :request do
   describe "GET /pwa/installation_instructions" do


### PR DESCRIPTION
PR #332 alerted me to the fact that `bin/setup`—specifically the `db:seed` command—was not working for new installs. I have been testing `bin/setup` in CI under for `RAILS_ENV=test` but I want to verify `RAILS_ENV=development`. This PR updates the CI workflow to ensure `bin/setup` works for `development`.

This CI job demonstrates the failure: https://github.com/joyofrails/joyofrails.com/actions/runs/12560902011/job/35018953158?pr=333