### PR TITLE
Convert html-to-image to dynamic import

### DIFF
--- a/app/javascript/controllers/snippets/screenshot.ts
+++ b/app/javascript/controllers/snippets/screenshot.ts
@@ -1,5 +1,4 @@
 import { Controller } from '@hotwired/stimulus';
-import * as htmlToImage from 'html-to-image';
 
 import { debug } from '../../utils';
 
@@ -53,6 +52,8 @@ export default class extends Controller<HTMLFormElement> {
   };
 
   drawScreenshot = async () => {
+    const htmlToImage = await import('html-to-image');
+
     return htmlToImage.toPng(this.snippetTarget);
   };
 }

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -1,7 +1,6 @@
 import debug from 'debug';
 
 import '@hotwired/turbo-rails';
-import * as htmlToImage from 'html-to-image';
 
 import '../controllers';
 
@@ -49,5 +48,3 @@ registerServiceWorker();
 turboScrollSmoothWorkaround();
 
 window.channels = channels;
-
-window.htmlToImage = htmlToImage;


### PR DESCRIPTION
There is absolutely no need to ship html-to-image in the application bundle. It had previously been included for experimentation from the console.

Since the "drawScreenshot" function is already asynchronous, it’s natural to inline the dynamic import.

This change I expect should decrease the application.js bundle size. 

Though I anticipate this change will work seamlessly in production, it will require some testing. Since the snippet screenshot feature is behind a feature flag, end users will not be adversely affected.