### PR TITLE
Fix for page caching

### DIFF
--- a/app/content/pages/about/design.html.mdrb
+++ b/app/content/pages/about/design.html.mdrb
@@ -7,7 +7,7 @@ I am [not a designer](https://notadesigner.io/). Though the design of this site 
 
 ## Layout
 
-The design leans heavily into [CSS grid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout) I’m a relatively new student of CSS grid so I’m sure the approach could be improved. I built a 12 column layout from using https://utopia.fyi to generate based grid, layout, and type settings as CSS variables. Utopia allows designers and developers to generate a mathematically consistent
+The design leans heavily into [CSS grid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout) I’m a relatively new student of CSS grid so I’m sure the approach could be improved. I built a 12 column layout using https://utopia.fyi to generate mathematically consistent grid, layout, and type settings as CSS variables.
 
 ## Colors
 
@@ -25,6 +25,6 @@ I want to Joy of Rails to "own more" of its dependencies—part of why I impleme
 
 When I was in grade school, I doodled a lot. Drawing brought me a lot of joy. After years of working at a computer, I got away from it. But more recently, especially now that I have kids of my own, I’ve had the itch to return to my roots.
 
-For Joy of Rails, I wanted to add some fun visuals to the in-depth articles. So, in this age of AI-generated imagery, I decided I would do the opposite of what everyone else seems to be doing—draw everything by hand. You‘ll pictures of rainbows, ice cream cones, and smiley faces on Joy of Rails as a reminder of the joy coding brings to my life.
+For Joy of Rails, I wanted to add some fun visuals to the in-depth articles. So, in this age of AI-generated imagery, I decided I would do the opposite of what everyone else seems to be doing—draw everything by hand. Pictures of rainbows, ice cream cones, and smiley faces on Joy of Rails serve as a reminder of the joy building and creating brings to my life.
 
 Most of the illustrations are done in [Procreate](https://procreate.com/) on my iPad with an Apple Pencil. Procreate is a great little app I highly recommend for anyone looking to rekindle their childhood doodling habit.

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -39,7 +39,9 @@ class SiteController < Sitepress::SiteController
   # @param rendition [Sitepress::Rendition] Rendered representatio of current_resource
   #
   def post_render(rendition)
-    if skip_http_cache? || stale?(rendition.source, last_modified: current_resource.asset.updated_at.utc, public: true)
+    last_modified_at = @current_page&.upserted_at || @current_page&.created_at || current_resource.asset.updated_at || Time.now
+
+    if skip_http_cache? || stale?(rendition.source, last_modified: last_modified_at.utc, public: true)
       render body: rendition.output, content_type: rendition.mime_type
     end
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -9,6 +9,8 @@
 #  indexed_at   :datetime
 #  published_at :datetime
 #  request_path :string           not null
+#  revised_at   :datetime
+#  upserted_at  :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #

--- a/app/models/page/sitepressed.rb
+++ b/app/models/page/sitepressed.rb
@@ -106,9 +106,9 @@ class Page
         enum.to_a
       end
 
-      def upsert_page_by_request_path!(request_path) = upsert_page_from_sitepress!(Sitepress.site.get(request_path))
+      def upsert_page_by_request_path!(request_path, **opts) = upsert_page_from_sitepress!(Sitepress.site.get(request_path), **opts)
 
-      def upsert_page_from_sitepress!(sitepress_resource) = upsert_page_from_resource! Resource.from(sitepress_resource)
+      def upsert_page_from_sitepress!(sitepress_resource, **opts) = upsert_page_from_resource!(Resource.from(sitepress_resource), **opts)
 
       def upsert_page_from_resource!(resource, upserted_at: Time.zone.now)
         page = find_or_initialize_by(request_path: resource.request_path)

--- a/db/cable_schema.rb
+++ b/db/cable_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_09_14_010017) do
+ActiveRecord::Schema[8.1].define(version: 2024_09_14_010017) do
   create_table "solid_cable_messages", force: :cascade do |t|
     t.binary "channel", limit: 1024, null: false
     t.binary "payload", limit: 536870912, null: false

--- a/db/cache_schema.rb
+++ b/db/cache_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_02_10_145644) do
+ActiveRecord::Schema[8.1].define(version: 2024_02_10_145644) do
   create_table "_litestream_lock", id: false, force: :cascade do |t|
     t.integer "id"
   end

--- a/db/migrate/20250116121529_add_revision_timestamps_to_pages.rb
+++ b/db/migrate/20250116121529_add_revision_timestamps_to_pages.rb
@@ -1,0 +1,6 @@
+class AddRevisionTimestampsToPages < ActiveRecord::Migration[8.1]
+  def change
+    add_column :pages, :revised_at, :datetime, null: true # For manually tracking content revisions
+    add_column :pages, :upserted_at, :datetime, null: true # For automatically tracking upserts
+  end
+end

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_10_25_223629) do
+ActiveRecord::Schema[8.1].define(version: 2024_10_25_223629) do
   create_table "_litestream_lock", id: false, force: :cascade do |t|
     t.integer "id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_06_145040) do
+ActiveRecord::Schema[8.1].define(version: 2025_01_16_121529) do
   create_table "_litestream_lock", id: false, force: :cascade do |t|
     t.integer "id"
   end
@@ -191,6 +191,8 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_06_145040) do
     t.datetime "updated_at", null: false
     t.datetime "published_at"
     t.datetime "indexed_at"
+    t.datetime "revised_at"
+    t.datetime "upserted_at"
     t.index ["indexed_at"], name: "index_pages_on_indexed_at"
     t.index ["published_at"], name: "index_pages_on_published_at"
     t.index ["request_path"], name: "index_pages_on_request_path", unique: true

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -6,6 +6,8 @@
 #  indexed_at   :datetime
 #  published_at :datetime
 #  request_path :string           not null
+#  revised_at   :datetime
+#  upserted_at  :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -6,6 +6,8 @@
 #  indexed_at   :datetime
 #  published_at :datetime
 #  request_path :string           not null
+#  revised_at   :datetime
+#  upserted_at  :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #


### PR DESCRIPTION
Joy of Rails recently reached page 1 of recent Hacker News—yay! It got to as high as #8 (from what I could see) on Jan 11, 2025:

![Screenshot 2025-01-11 at 3 44 07 PM](https://github.com/user-attachments/assets/721f664e-a157-47d9-b591-e40c07af06f2)

Some visitors complained the site wasn’t able to load properly. One person emailed a screenshot of their browser which displayed the unstyled HTML which would indicate assets weren’t loading. Another mentioned that <html> and <body> tags were missing in the response. It appear the issue(s) only affected a small subset of visitors. 

The person who emailed wrote back a few days later to say the site was working again.

My best guess at the moment is that HTTP caching may have led to stale responses in some regions.

The Joy of Rails SiteController, which serves the [Sitepress](https://github.com/sitepress/sitepress)-backed static content for articles, has some logic to add HTTP caching headers. Previously, I’ve used `File.mtime` to set the "Last Modified" response header (per [Sitepress asset logic](https://github.com/sitepress/sitepress/blob/72600fdd98289157627d6938d022a1b34116da14/sitepress-core/lib/sitepress/asset.rb#L69)). But this is not a good proxy for whether the actual page has change; it’s possible other parts of the HTML response, such as header content or asset bundle URLs, where more recently updated since the content source file was modified on disk.

To address this issue, I’m adding a `upserted_at` timestamp to each `Page` record. Page records are used as a DB-backed adapters for each of the Sitepress resources. During each deploy, we already loop through Sitepress resources to upsert the corresponding Page records. During upsert, we now set an `upserted_at` timestamp. We’ll use this timestamp to set the "Last Modified" header in SiteController for the given page. We fall back to `created_at`, then `File.mtime` otherwise.

I also have added a `revised_at` timestamp to Page to be set during upsert. This is only an authoring mechansim; when I want to display a public view of when content was most recently modifed, I’ll used `revised_at`.