### PR TITLE
Fix for solid queue error when db pool count mismatched

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,7 @@
 default: &default
   encoding: utf8
   adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 3 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 4 } %>
   timeout: 5000
   extensions:
     - SqliteExt::Ulid


### PR DESCRIPTION
Fixes the following error after the recent Solid Queue upgrade:

```
Solid Queue is configured to use 4 threads but the database connection pool is 3. Increase it in `config/database.yml`
```

Joy of Rails’ Solid Queue is configured to have a thread pool count of 4 (2 threads for workers + 1 thread for the worker itself + 1 thread for the heartbeat task): 

A change was recently added to error when it detects a mismatch in the DB pool count.

https://github.com/rails/solid_queue/pull/457

This change updates config/database.yml to match the Solid Queue default.

A nice improvement would be to make sure Solid Queue can boot in CI.

<!-- Describe your changes and link to relevant issues or discussions. Please add motivation and context as needed. -->

## Pull request checklist

- [ ] I have written tests for code I have added or modified.
- [ ] I linted and tested the project with `bin/verify`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
