### PR TITLE
Override new Mission Control Jobs auth default

### DIFF
--- a/config/initializers/mission_control.rb
+++ b/config/initializers/mission_control.rb
@@ -1,0 +1,3 @@
+# We use route constraints for AdminUser to gate access to the
+# MissionControl::Jobs engine
+MissionControl::Jobs.http_basic_auth_enabled = false


### PR DESCRIPTION
The latest upgrade of Mission Control Jobs defaults to use http basic auth before_action to gate access to the jobs dashboard. Since we’ve already implemented an auth mechanism (with tests) bbehind Warden and AdminUser, the new MCJ feature isn’t needed. We disable it in this change.

<!-- Describe your changes and link to relevant issues or discussions. Please add motivation and context as needed. -->

## Pull request checklist

- [ ] I have written tests for code I have added or modified.
- [x] I linted and tested the project with `bin/verify`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
