### PR TITLE
FIX: typo in manifest since we magick'ed into images dir

### DIFF
--- a/app/content/pages/articles/add-your-rails-app-to-the-home-screen.html.mdrb
+++ b/app/content/pages/articles/add-your-rails-app-to-the-home-screen.html.mdrb
@@ -289,12 +289,12 @@ In your manifest, you can add variations for each size and mark their `purpose` 
   // ...
   "icons": [
     {
-      "src": "<%= asset_path("app-icons/icon-192.png") %>",
+      "src": "<%= image_path("app-icons/icon-192.png") %>",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "<%= asset_path("app-icons/icon-192-maskable.png") %>",
+      "src": "<%= image_path("app-icons/icon-192-maskable.png") %>",
       "type": "image/png",
       "sizes": "192x192",
       "purpose": "maskable"


### PR DESCRIPTION
propshaft need `image_path` for images under `images` dir
